### PR TITLE
feat: fix README drift + add date-range historical, forecasts, storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The official Go SDK for [OilPriceAPI](https://www.oilpriceapi.com) - Real-time a
 - **Typed Errors** - Custom error types for authentication, rate limits, and server errors
 - **Automatic Retries** - Configurable retry with exponential backoff
 - **Zero Dependencies** - Uses only the Go standard library
-- **Comprehensive Coverage** - Latest prices, historical data, futures, storage, rig counts, drilling, marine fuels, and webhooks
+- **Comprehensive Coverage** - Latest prices, historical data (fixed periods or custom date ranges), forecasts, futures, storage, rig counts, drilling, marine fuels, and webhooks
 
 ## Installation
 
@@ -133,20 +133,29 @@ prices, err := client.GetLatestPrices(ctx, oilpriceapi.WithCommodity("WTI_USD"))
 
 ### Historical Prices
 
+The commodity code is the first positional argument. Use `WithPeriod` for a
+fixed lookback window (`"day"`, `"week"`, `"month"`, or `"year"`; defaults to
+`"month"`), or `WithStartDate`/`WithEndDate` for a custom range.
+
 ```go
-// Past week
-prices, err := client.GetHistoricalPrices(ctx,
-    oilpriceapi.WithPeriod("past_week"),
-    oilpriceapi.WithCommodity("BRENT_CRUDE_USD"),
+// Fixed period (defaults to the past month)
+prices, err := client.GetHistoricalPrices(ctx, "BRENT_CRUDE_USD")
+
+// Explicit period
+prices, err := client.GetHistoricalPrices(ctx, "BRENT_CRUDE_USD",
+    oilpriceapi.WithPeriod("week"),
 )
 
 // Custom date range with daily aggregation
-prices, err := client.GetHistoricalPrices(ctx,
+prices, err := client.GetHistoricalPrices(ctx, "WTI_USD",
     oilpriceapi.WithStartDate("2024-01-01"),
     oilpriceapi.WithEndDate("2024-12-31"),
-    oilpriceapi.WithCommodity("WTI_USD"),
     oilpriceapi.WithInterval("daily"),
 )
+
+for _, p := range prices.Data.Prices {
+    fmt.Printf("%s: $%.2f\n", p.CreatedAt, p.Price)
+}
 ```
 
 ### Commodities List
@@ -160,35 +169,84 @@ for _, c := range commodities.Data.Commodities {
 
 ### Futures Contracts
 
-```go
-// Get latest front month futures price
-futures, err := client.GetFuturesLatest(ctx, "CL.1")
-fmt.Printf("WTI Front Month: $%.2f\n", futures.Price)
+The futures contract is selected with `WithContract` (`"BZ"` for Brent or
+`"CL"` for WTI; defaults to `"BZ"`).
 
-// Get futures curve
-curve, err := client.GetFuturesCurve(ctx, "CL")
-for _, point := range curve.Curve {
-    fmt.Printf("%d months out: $%.2f\n", point.MonthsOut, point.Price)
+```go
+// Get latest futures contracts (defaults to Brent / BZ)
+futures, err := client.GetFuturesLatest(ctx)
+for _, c := range futures.Data.Contracts {
+    fmt.Printf("%s (%s): $%.2f\n", c.Contract, c.Month, c.Price)
 }
+
+// Get the WTI forward curve
+curve, err := client.GetFuturesCurve(ctx, oilpriceapi.WithContract("CL"))
+for _, c := range curve.Data.Contracts {
+    fmt.Printf("%s: $%.2f\n", c.Month, c.Price)
+}
+```
+
+### Forecasts
+
+```go
+// Monthly forecasts for all commodities
+forecasts, err := client.GetForecasts(ctx)
+for _, f := range forecasts.Data.Commodities {
+    fmt.Printf("%s 1-month: $%.2f\n", f.Commodity, f.Forecasts["1_month"].PointEstimate)
+}
+
+// Forecast for a single commodity
+wti, err := client.GetForecasts(ctx, oilpriceapi.WithForecastCommodity("WTI_USD"))
+fmt.Printf("WTI 3-month: $%.2f\n", wti.Data.Forecasts["3_month"].PointEstimate)
+
+// Backtested model accuracy
+accuracy, err := client.GetForecastsAccuracy(ctx,
+    oilpriceapi.WithLookbackMonths(24),
+)
+fmt.Printf("1-month MAPE: %.1f%%\n", accuracy.Data.Statistics.AvgMAPE1M)
 ```
 
 ### Storage Levels
 
 ```go
-// Cushing hub levels
+// All tracked hubs (Cushing, US SPR, regional)
+storage, err := client.GetStorage(ctx)
+for _, s := range storage.Data.Storage {
+    fmt.Printf("%s: %.1f %s\n", s.Location, s.Value, s.Units)
+}
+
+// Cushing hub detail with analytics
 cushing, err := client.GetStorageCushing(ctx)
-fmt.Printf("Cushing: %s %s\n", cushing.Level, cushing.Unit)
+fmt.Printf("Cushing: %.1f %s\n", cushing.Data.Storage.Current.Value, cushing.Data.Storage.Current.Units)
 
 // Strategic Petroleum Reserve
 spr, err := client.GetStorageSPR(ctx)
-fmt.Printf("SPR: %s %s\n", spr.Level, spr.Unit)
+fmt.Printf("SPR: %.1f %s\n", spr.Data.Storage.Current.Value, spr.Data.Storage.Current.Units)
 ```
 
 ### Rig Counts
 
 ```go
-rigCounts, err := client.GetRigCountsLatest(ctx)
-fmt.Printf("Total: %d, Oil: %d, Gas: %d\n", rigCounts.Total, rigCounts.Oil, rigCounts.Gas)
+rigCounts, err := client.GetRigCounts(ctx)
+fmt.Printf("Total: %d, Oil: %d, Gas: %d\n",
+    rigCounts.Data.Total, rigCounts.Data.Oil, rigCounts.Data.Gas)
+```
+
+### Marine Fuels
+
+```go
+fuels, err := client.GetMarineFuels(ctx)
+for _, p := range fuels.Data.Prices {
+    fmt.Printf("%s %s: $%.2f %s/%s\n", p.Port, p.FuelType, p.Price, p.Currency, p.Unit)
+}
+```
+
+### Drilling Intelligence
+
+```go
+drilling, err := client.GetDrillingIntelligence(ctx)
+fmt.Printf("Active rigs: %d, total wells: %d\n",
+    drilling.Data.ActiveRigs, drilling.Data.TotalWells)
 ```
 
 ## Error Handling

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -19,7 +20,7 @@ const (
 	// DefaultRetries is the default number of retries.
 	DefaultRetries = 3
 	// Version is the SDK version.
-	Version = "1.0.0"
+	Version = "1.1.0"
 )
 
 // Client is the Oil Price API client.
@@ -201,6 +202,24 @@ var validPeriods = map[string]bool{
 }
 
 // GetHistoricalPrices fetches historical price data for a commodity.
+//
+// By default it queries one of the fixed-period endpoints
+// (/v1/prices/past_day, past_week, past_month, past_year) selected via
+// WithPeriod. Supplying WithStartDate and/or WithEndDate switches to the
+// flexible /v1/prices/historical endpoint, which supports an arbitrary date
+// range and an optional aggregation interval set via WithInterval.
+//
+// Example:
+//
+//	// Fixed period (last month)
+//	prices, err := client.GetHistoricalPrices(ctx, "BRENT_CRUDE_USD")
+//
+//	// Custom date range with daily aggregation
+//	prices, err := client.GetHistoricalPrices(ctx, "WTI_USD",
+//	    oilpriceapi.WithStartDate("2024-01-01"),
+//	    oilpriceapi.WithEndDate("2024-12-31"),
+//	    oilpriceapi.WithInterval("daily"),
+//	)
 func (c *Client) GetHistoricalPrices(ctx context.Context, commodity string, opts ...HistoricalOption) (*HistoricalResponse, error) {
 	options := &HistoricalOptions{
 		Commodity: commodity,
@@ -210,11 +229,25 @@ func (c *Client) GetHistoricalPrices(ctx context.Context, commodity string, opts
 		opt(options)
 	}
 
-	if !validPeriods[options.Period] {
-		return nil, fmt.Errorf("invalid period %q: must be one of \"day\", \"week\", \"month\", \"year\"", options.Period)
+	var endpoint string
+	if options.StartDate != "" || options.EndDate != "" {
+		// Flexible date-range endpoint.
+		endpoint = fmt.Sprintf("/v1/prices/historical?by_code=%s", url.QueryEscape(options.Commodity))
+		if options.StartDate != "" {
+			endpoint += "&start_date=" + url.QueryEscape(options.StartDate)
+		}
+		if options.EndDate != "" {
+			endpoint += "&end_date=" + url.QueryEscape(options.EndDate)
+		}
+		if options.Interval != "" {
+			endpoint += "&interval=" + url.QueryEscape(options.Interval)
+		}
+	} else {
+		if !validPeriods[options.Period] {
+			return nil, fmt.Errorf("invalid period %q: must be one of \"day\", \"week\", \"month\", \"year\"", options.Period)
+		}
+		endpoint = fmt.Sprintf("/v1/prices/past_%s?by_code=%s", options.Period, url.QueryEscape(options.Commodity))
 	}
-
-	endpoint := fmt.Sprintf("/v1/prices/past_%s?by_code=%s", options.Period, options.Commodity)
 	if options.Page > 0 {
 		endpoint += fmt.Sprintf("&page=%d", options.Page)
 	}
@@ -233,6 +266,149 @@ func (c *Client) GetHistoricalPrices(ctx context.Context, commodity string, opts
 	}
 
 	var result HistoricalResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetForecasts fetches monthly price forecasts.
+//
+// Without options it returns the latest forecasts for all supported
+// commodities. Use WithForecastCommodity to fetch the forecast for a single
+// commodity.
+//
+// Example:
+//
+//	// All commodities
+//	forecasts, err := client.GetForecasts(ctx)
+//	for _, f := range forecasts.Data.Commodities {
+//	    fmt.Printf("%s 1m: $%.2f\n", f.Commodity, f.Forecasts["1_month"].PointEstimate)
+//	}
+//
+//	// Single commodity
+//	wti, err := client.GetForecasts(ctx, oilpriceapi.WithForecastCommodity("WTI_USD"))
+func (c *Client) GetForecasts(ctx context.Context, opts ...ForecastsOption) (*ForecastsResponse, error) {
+	options := &ForecastsOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	endpoint := "/v1/forecasts/monthly"
+	if options.Commodity != "" {
+		endpoint += "?commodity=" + url.QueryEscape(options.Commodity)
+	}
+
+	resp, err := c.doRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var result ForecastsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetForecastsAccuracy fetches aggregate accuracy statistics for the monthly
+// forecast model.
+//
+// Use WithForecastCommodity to scope to a single commodity and
+// WithLookbackMonths to set the lookback window (3-36 months, default 12).
+func (c *Client) GetForecastsAccuracy(ctx context.Context, opts ...ForecastsOption) (*ForecastAccuracyResponse, error) {
+	options := &ForecastsOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	query := url.Values{}
+	if options.Commodity != "" {
+		query.Set("commodity", options.Commodity)
+	}
+	if options.LookbackMonths > 0 {
+		query.Set("lookback_months", strconv.Itoa(options.LookbackMonths))
+	}
+
+	endpoint := "/v1/forecasts/monthly/accuracy"
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+
+	resp, err := c.doRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var result ForecastAccuracyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetStorage fetches the latest storage levels across all tracked hubs
+// (Cushing, US SPR, and regional storage).
+//
+// Example:
+//
+//	storage, err := client.GetStorage(ctx)
+//	for _, s := range storage.Data.Storage {
+//	    fmt.Printf("%s: %.1f %s\n", s.Location, s.Value, s.Units)
+//	}
+func (c *Client) GetStorage(ctx context.Context) (*StorageResponse, error) {
+	resp, err := c.doRequest(ctx, "GET", "/v1/storage", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var result StorageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetStorageCushing fetches detailed storage levels and analytics for the
+// Cushing, Oklahoma hub.
+func (c *Client) GetStorageCushing(ctx context.Context) (*StorageHubResponse, error) {
+	return c.getStorageHub(ctx, "/v1/storage/cushing")
+}
+
+// GetStorageSPR fetches detailed storage levels and analytics for the US
+// Strategic Petroleum Reserve.
+func (c *Client) GetStorageSPR(ctx context.Context) (*StorageHubResponse, error) {
+	return c.getStorageHub(ctx, "/v1/storage/spr")
+}
+
+// getStorageHub is the shared implementation for single-hub storage endpoints.
+func (c *Client) getStorageHub(ctx context.Context, endpoint string) (*StorageHubResponse, error) {
+	resp, err := c.doRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var result StorageHubResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1091,3 +1091,442 @@ func TestRetryBehavior(t *testing.T) {
 		}
 	})
 }
+
+// ===================
+// DATE-RANGE HISTORICAL
+// ===================
+
+func TestGetHistoricalPricesDateRange(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          []HistoricalOption
+		wantPath      string
+		wantStart     string
+		wantEnd       string
+		wantInterval  string
+		wantByCode    string
+		wantPageQuery string
+	}{
+		{
+			name:       "start date only routes to /historical",
+			opts:       []HistoricalOption{WithStartDate("2024-01-01")},
+			wantPath:   "/v1/prices/historical",
+			wantStart:  "2024-01-01",
+			wantByCode: "WTI_USD",
+		},
+		{
+			name:         "full range with interval",
+			opts:         []HistoricalOption{WithStartDate("2024-01-01"), WithEndDate("2024-12-31"), WithInterval("daily")},
+			wantPath:     "/v1/prices/historical",
+			wantStart:    "2024-01-01",
+			wantEnd:      "2024-12-31",
+			wantInterval: "daily",
+			wantByCode:   "WTI_USD",
+		},
+		{
+			name:       "end date only routes to /historical",
+			opts:       []HistoricalOption{WithEndDate("2024-06-30")},
+			wantPath:   "/v1/prices/historical",
+			wantEnd:    "2024-06-30",
+			wantByCode: "WTI_USD",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tt.wantPath {
+					t.Errorf("expected path %s, got %s", tt.wantPath, r.URL.Path)
+				}
+				q := r.URL.Query()
+				if q.Get("by_code") != tt.wantByCode {
+					t.Errorf("expected by_code=%s, got %s", tt.wantByCode, q.Get("by_code"))
+				}
+				if q.Get("start_date") != tt.wantStart {
+					t.Errorf("expected start_date=%q, got %q", tt.wantStart, q.Get("start_date"))
+				}
+				if q.Get("end_date") != tt.wantEnd {
+					t.Errorf("expected end_date=%q, got %q", tt.wantEnd, q.Get("end_date"))
+				}
+				if q.Get("interval") != tt.wantInterval {
+					t.Errorf("expected interval=%q, got %q", tt.wantInterval, q.Get("interval"))
+				}
+
+				response := HistoricalResponse{
+					Status: "success",
+					Data: HistoricalData{
+						Prices: []HistoricalPrice{
+							{Price: 75.42, CreatedAt: "2024-01-10T00:00:00Z", Code: "WTI_USD", Currency: "USD", Formatted: "$75.42", Type: "daily_average", Unit: "barrel", Source: "aggregated"},
+						},
+					},
+				}
+				json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			client := NewClient("test-key", WithBaseURL(server.URL))
+			resp, err := client.GetHistoricalPrices(context.Background(), "WTI_USD", tt.opts...)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if len(resp.Data.Prices) != 1 {
+				t.Fatalf("expected 1 price, got %d", len(resp.Data.Prices))
+			}
+			if resp.Data.Prices[0].Currency != "USD" {
+				t.Errorf("expected currency USD, got %s", resp.Data.Prices[0].Currency)
+			}
+			if resp.Data.Prices[0].Source != "aggregated" {
+				t.Errorf("expected source aggregated, got %s", resp.Data.Prices[0].Source)
+			}
+		})
+	}
+
+	t.Run("date range still passes pagination", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/prices/historical" {
+				t.Errorf("expected /v1/prices/historical, got %s", r.URL.Path)
+			}
+			if r.URL.Query().Get("page") != "3" {
+				t.Errorf("expected page=3, got %s", r.URL.Query().Get("page"))
+			}
+			json.NewEncoder(w).Encode(HistoricalResponse{Status: "success"})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		_, err := client.GetHistoricalPrices(context.Background(), "WTI_USD", WithStartDate("2024-01-01"), WithPage(3))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("returns error on non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error": "not found"}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(0))
+		_, err := client.GetHistoricalPrices(context.Background(), "WTI_USD", WithStartDate("2024-01-01"))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !isNotFoundError(err) {
+			t.Errorf("expected NotFoundError, got %T: %v", err, err)
+		}
+	})
+}
+
+// ===================
+// FORECASTS
+// ===================
+
+func TestGetForecasts(t *testing.T) {
+	t.Run("fetches all-commodity forecasts", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/forecasts/monthly" {
+				t.Errorf("expected path /v1/forecasts/monthly, got %s", r.URL.Path)
+			}
+			if r.URL.Query().Get("commodity") != "" {
+				t.Errorf("expected no commodity filter, got %s", r.URL.Query().Get("commodity"))
+			}
+			if r.Header.Get("Authorization") != "Token test-key" {
+				t.Errorf("expected auth header, got %s", r.Header.Get("Authorization"))
+			}
+
+			response := ForecastsResponse{
+				Data: ForecastsData{
+					Period:      "2026-02",
+					GeneratedAt: "2026-01-15T00:00:00Z",
+					Commodities: []Forecast{
+						{
+							Commodity:         "WTI_USD",
+							GeneratedForMonth: "2026-01",
+							Forecasts: map[string]ForecastHorizon{
+								"1_month": {Period: "2026-02", PointEstimate: 78.5, LowBound: 74.0, HighBound: 83.0, Confidence: 0.8},
+							},
+							ModelInputs: ForecastModelInputs{EMATrendValue: 77.2},
+						},
+					},
+					Disclaimer: "Forecasts are estimates.",
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.GetForecasts(context.Background())
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Data.Period != "2026-02" {
+			t.Errorf("expected period 2026-02, got %s", resp.Data.Period)
+		}
+		if len(resp.Data.Commodities) != 1 {
+			t.Fatalf("expected 1 commodity, got %d", len(resp.Data.Commodities))
+		}
+		fc := resp.Data.Commodities[0]
+		if fc.Commodity != "WTI_USD" {
+			t.Errorf("expected WTI_USD, got %s", fc.Commodity)
+		}
+		if fc.Forecasts["1_month"].PointEstimate != 78.5 {
+			t.Errorf("expected 1m point 78.5, got %f", fc.Forecasts["1_month"].PointEstimate)
+		}
+	})
+
+	t.Run("fetches single-commodity forecast", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("commodity") != "BRENT_CRUDE_USD" {
+				t.Errorf("expected commodity=BRENT_CRUDE_USD, got %s", r.URL.Query().Get("commodity"))
+			}
+			response := ForecastsResponse{
+				Data: ForecastsData{
+					Commodity:         "BRENT_CRUDE_USD",
+					GeneratedForMonth: "2026-01",
+					Forecasts: map[string]ForecastHorizon{
+						"3_month": {Period: "2026-04", PointEstimate: 82.0, Confidence: 0.6},
+					},
+					Accuracy: &ForecastAccuracy{MAPE1M: 3.2, DirectionCorrect1M: true},
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.GetForecasts(context.Background(), WithForecastCommodity("BRENT_CRUDE_USD"))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Data.Commodity != "BRENT_CRUDE_USD" {
+			t.Errorf("expected commodity BRENT_CRUDE_USD, got %s", resp.Data.Commodity)
+		}
+		if resp.Data.Forecasts["3_month"].PointEstimate != 82.0 {
+			t.Errorf("expected 3m point 82.0, got %f", resp.Data.Forecasts["3_month"].PointEstimate)
+		}
+		if resp.Data.Accuracy == nil || !resp.Data.Accuracy.DirectionCorrect1M {
+			t.Errorf("expected accuracy with DirectionCorrect1M=true, got %+v", resp.Data.Accuracy)
+		}
+	})
+
+	t.Run("returns error on non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error": "No forecasts available"}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(0))
+		_, err := client.GetForecasts(context.Background())
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !isNotFoundError(err) {
+			t.Errorf("expected NotFoundError, got %T: %v", err, err)
+		}
+	})
+}
+
+func TestGetForecastsAccuracy(t *testing.T) {
+	t.Run("fetches accuracy stats with options", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/forecasts/monthly/accuracy" {
+				t.Errorf("expected path /v1/forecasts/monthly/accuracy, got %s", r.URL.Path)
+			}
+			if r.URL.Query().Get("commodity") != "WTI_USD" {
+				t.Errorf("expected commodity=WTI_USD, got %s", r.URL.Query().Get("commodity"))
+			}
+			if r.URL.Query().Get("lookback_months") != "24" {
+				t.Errorf("expected lookback_months=24, got %s", r.URL.Query().Get("lookback_months"))
+			}
+
+			response := ForecastAccuracyResponse{
+				Data: ForecastAccuracyData{
+					LookbackMonths: 24,
+					Commodity:      "WTI_USD",
+					Statistics: ForecastAccuracyStatistics{
+						SampleSize:            18,
+						AvgMAPE1M:             3.5,
+						DirectionalAccuracy1M: 72.2,
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.GetForecastsAccuracy(context.Background(), WithForecastCommodity("WTI_USD"), WithLookbackMonths(24))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Data.Statistics.SampleSize != 18 {
+			t.Errorf("expected sample_size 18, got %d", resp.Data.Statistics.SampleSize)
+		}
+		if resp.Data.Statistics.DirectionalAccuracy1M != 72.2 {
+			t.Errorf("expected directional accuracy 72.2, got %f", resp.Data.Statistics.DirectionalAccuracy1M)
+		}
+	})
+
+	t.Run("omits query params when unset", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.RawQuery != "" {
+				t.Errorf("expected empty query, got %q", r.URL.RawQuery)
+			}
+			json.NewEncoder(w).Encode(ForecastAccuracyResponse{Data: ForecastAccuracyData{LookbackMonths: 12}})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		_, err := client.GetForecastsAccuracy(context.Background())
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+}
+
+// ===================
+// STORAGE
+// ===================
+
+func TestGetStorage(t *testing.T) {
+	t.Run("fetches all storage levels", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/storage" {
+				t.Errorf("expected path /v1/storage, got %s", r.URL.Path)
+			}
+			if r.Header.Get("Authorization") != "Token test-key" {
+				t.Errorf("expected auth header, got %s", r.Header.Get("Authorization"))
+			}
+
+			response := StorageResponse{
+				Status: "success",
+				Data: StorageData{
+					Storage: []StorageLevel{
+						{Code: "CUSHING_STORAGE", Location: "Cushing, OK", Value: 28.4, Units: "million_barrels", CapacityUtilization: 37.4, MarketSignal: "bearish", DataDate: "2024-01-10"},
+						{Code: "US_SPR", Location: "Strategic Petroleum Reserve", Value: 351.3, Units: "million_barrels", DataDate: "2024-01-10"},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.GetStorage(context.Background())
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Data.Storage) != 2 {
+			t.Fatalf("expected 2 storage levels, got %d", len(resp.Data.Storage))
+		}
+		if resp.Data.Storage[0].Code != "CUSHING_STORAGE" {
+			t.Errorf("expected CUSHING_STORAGE, got %s", resp.Data.Storage[0].Code)
+		}
+		if resp.Data.Storage[0].Value != 28.4 {
+			t.Errorf("expected value 28.4, got %f", resp.Data.Storage[0].Value)
+		}
+	})
+
+	t.Run("returns error on non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error": "Unauthorized"}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("bad-key", WithBaseURL(server.URL), WithRetries(0))
+		_, err := client.GetStorage(context.Background())
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !isAuthError(err) {
+			t.Errorf("expected AuthenticationError, got %T: %v", err, err)
+		}
+	})
+}
+
+func TestGetStorageHubs(t *testing.T) {
+	tests := []struct {
+		name     string
+		call     func(*Client) (*StorageHubResponse, error)
+		wantPath string
+	}{
+		{
+			name:     "cushing",
+			call:     func(c *Client) (*StorageHubResponse, error) { return c.GetStorageCushing(context.Background()) },
+			wantPath: "/v1/storage/cushing",
+		},
+		{
+			name:     "spr",
+			call:     func(c *Client) (*StorageHubResponse, error) { return c.GetStorageSPR(context.Background()) },
+			wantPath: "/v1/storage/spr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tt.wantPath {
+					t.Errorf("expected path %s, got %s", tt.wantPath, r.URL.Path)
+				}
+				response := StorageHubResponse{
+					Status: "success",
+					Data: StorageHubData{
+						Storage: StorageHub{
+							Current: StorageHubCurrent{
+								Value:               28.4,
+								Units:               "million_barrels",
+								CapacityUtilization: 37.4,
+								WeekOverWeekChange:  -0.5,
+								DataDate:            "2024-01-10",
+							},
+							Analytics: StorageHubAnalytics{
+								MarketSignal: "bearish",
+								Week52High:   34.1,
+								Week52Low:    22.0,
+							},
+							Metadata: StorageHubMetadata{
+								Source:        "EIA",
+								TotalCapacity: 76,
+							},
+						},
+					},
+				}
+				json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			client := NewClient("test-key", WithBaseURL(server.URL))
+			resp, err := tt.call(client)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if resp.Data.Storage.Current.Value != 28.4 {
+				t.Errorf("expected value 28.4, got %f", resp.Data.Storage.Current.Value)
+			}
+			if resp.Data.Storage.Analytics.MarketSignal != "bearish" {
+				t.Errorf("expected market_signal bearish, got %s", resp.Data.Storage.Analytics.MarketSignal)
+			}
+			if resp.Data.Storage.Metadata.TotalCapacity != 76 {
+				t.Errorf("expected total_capacity 76, got %f", resp.Data.Storage.Metadata.TotalCapacity)
+			}
+		})
+	}
+
+	t.Run("returns error on non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error": "Premium feature"}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(0))
+		_, err := client.GetStorageCushing(context.Background())
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/example/main.go
+++ b/example/main.go
@@ -65,4 +65,37 @@ func main() {
 	}
 
 	fmt.Printf("\nAvailable Commodities: %d\n", len(commodities.Data.Commodities))
+
+	// Date-range historical prices with daily aggregation
+	history, err := client.GetHistoricalPrices(context.Background(), "WTI_USD",
+		oilpriceapi.WithStartDate("2024-01-01"),
+		oilpriceapi.WithEndDate("2024-03-31"),
+		oilpriceapi.WithInterval("daily"))
+	if err != nil {
+		log.Printf("Error getting historical range: %v\n", err)
+	} else {
+		fmt.Printf("\nWTI history points (Q1 2024): %d\n", len(history.Data.Prices))
+	}
+
+	// Monthly forecasts
+	forecasts, err := client.GetForecasts(context.Background())
+	if err != nil {
+		log.Printf("Error getting forecasts: %v\n", err)
+	} else {
+		fmt.Printf("\nForecasts for %s:\n", forecasts.Data.Period)
+		for _, f := range forecasts.Data.Commodities {
+			fmt.Printf("  %s 1-month: $%.2f\n", f.Commodity, f.Forecasts["1_month"].PointEstimate)
+		}
+	}
+
+	// Storage levels
+	storage, err := client.GetStorage(context.Background())
+	if err != nil {
+		log.Printf("Error getting storage: %v\n", err)
+	} else {
+		fmt.Println("\nStorage Levels:")
+		for _, s := range storage.Data.Storage {
+			fmt.Printf("  %s: %.1f %s\n", s.Location, s.Value, s.Units)
+		}
+	}
 }

--- a/types.go
+++ b/types.go
@@ -96,10 +96,20 @@ func WithCommodity(code string) LatestPricesOption {
 }
 
 // HistoricalPrice represents a single historical price point.
+//
+// The Currency, Formatted, Type, PriceType, Unit, and Source fields are only
+// populated by the flexible date-range endpoint (/v1/prices/historical); the
+// fixed-period endpoints leave them empty.
 type HistoricalPrice struct {
 	Price     float64 `json:"price"`
 	CreatedAt string  `json:"created_at"`
 	Code      string  `json:"code,omitempty"`
+	Currency  string  `json:"currency,omitempty"`
+	Formatted string  `json:"formatted,omitempty"`
+	Type      string  `json:"type,omitempty"`
+	PriceType string  `json:"price_type,omitempty"`
+	Unit      string  `json:"unit,omitempty"`
+	Source    string  `json:"source,omitempty"`
 }
 
 // HistoricalData contains the data from a historical prices response.
@@ -230,6 +240,9 @@ type WebhookResponse struct {
 type HistoricalOptions struct {
 	Commodity string
 	Period    string
+	StartDate string
+	EndDate   string
+	Interval  string
 	Page      int
 	PerPage   int
 }
@@ -241,6 +254,34 @@ type HistoricalOption func(*HistoricalOptions)
 func WithPeriod(period string) HistoricalOption {
 	return func(o *HistoricalOptions) {
 		o.Period = period
+	}
+}
+
+// WithStartDate sets the start of a custom date range (YYYY-MM-DD).
+//
+// Setting a start or end date routes the request to /v1/prices/historical
+// instead of the fixed-period endpoints.
+func WithStartDate(date string) HistoricalOption {
+	return func(o *HistoricalOptions) {
+		o.StartDate = date
+	}
+}
+
+// WithEndDate sets the end of a custom date range (YYYY-MM-DD).
+//
+// Setting a start or end date routes the request to /v1/prices/historical
+// instead of the fixed-period endpoints.
+func WithEndDate(date string) HistoricalOption {
+	return func(o *HistoricalOptions) {
+		o.EndDate = date
+	}
+}
+
+// WithInterval sets the aggregation interval for date-range historical queries
+// (e.g. "daily", "weekly", "monthly", "hourly", "raw").
+func WithInterval(interval string) HistoricalOption {
+	return func(o *HistoricalOptions) {
+		o.Interval = interval
 	}
 }
 
@@ -271,4 +312,187 @@ func WithContract(contract string) FuturesOption {
 	return func(o *FuturesOptions) {
 		o.Contract = contract
 	}
+}
+
+// ForecastHorizon represents a single forecast horizon (e.g. 1-month, 3-month).
+type ForecastHorizon struct {
+	Period        string  `json:"period"`
+	PointEstimate float64 `json:"point_estimate"`
+	LowBound      float64 `json:"low_bound"`
+	HighBound     float64 `json:"high_bound"`
+	Confidence    float64 `json:"confidence"`
+}
+
+// ForecastModelInputs contains the model signals used to generate a forecast.
+type ForecastModelInputs struct {
+	EMATrendValue   float64 `json:"ema_trend_value"`
+	EIASTEOValue    float64 `json:"eia_steo_value"`
+	InventorySignal float64 `json:"inventory_signal"`
+	RigCountSignal  float64 `json:"rig_count_signal"`
+}
+
+// ForecastAccuracy contains backtested accuracy information for a forecast.
+type ForecastAccuracy struct {
+	ActualPrice1M      float64 `json:"actual_price_1m"`
+	ActualPrice3M      float64 `json:"actual_price_3m"`
+	MAPE1M             float64 `json:"mape_1m"`
+	MAPE3M             float64 `json:"mape_3m"`
+	DirectionCorrect1M bool    `json:"direction_correct_1m"`
+	DirectionCorrect3M bool    `json:"direction_correct_3m"`
+}
+
+// Forecast represents a monthly price forecast for a single commodity.
+type Forecast struct {
+	Commodity         string                     `json:"commodity"`
+	GeneratedAt       string                     `json:"generated_at"`
+	GeneratedForMonth string                     `json:"generated_for_month"`
+	Forecasts         map[string]ForecastHorizon `json:"forecasts"`
+	ModelInputs       ForecastModelInputs        `json:"model_inputs"`
+	Drivers           []string                   `json:"drivers,omitempty"`
+	Accuracy          *ForecastAccuracy          `json:"accuracy,omitempty"`
+	ModelVersion      string                     `json:"model_version,omitempty"`
+	Disclaimer        string                     `json:"disclaimer,omitempty"`
+}
+
+// ForecastsData contains the data from a forecasts response.
+//
+// When no commodity is requested the API returns the full set in Commodities
+// along with the top-level Period and GeneratedAt. When a single commodity is
+// requested, the API returns that forecast directly, so the Commodity,
+// Forecasts, ModelInputs, Drivers, and Accuracy fields are populated and
+// Commodities is empty.
+type ForecastsData struct {
+	// Multi-commodity fields.
+	Period      string     `json:"period,omitempty"`
+	Commodities []Forecast `json:"commodities,omitempty"`
+
+	// Single-commodity fields (also covers fields shared with Forecast).
+	Commodity         string                     `json:"commodity,omitempty"`
+	GeneratedAt       string                     `json:"generated_at,omitempty"`
+	GeneratedForMonth string                     `json:"generated_for_month,omitempty"`
+	Forecasts         map[string]ForecastHorizon `json:"forecasts,omitempty"`
+	ModelInputs       ForecastModelInputs        `json:"model_inputs,omitempty"`
+	Drivers           []string                   `json:"drivers,omitempty"`
+	Accuracy          *ForecastAccuracy          `json:"accuracy,omitempty"`
+	ModelVersion      string                     `json:"model_version,omitempty"`
+	Disclaimer        string                     `json:"disclaimer,omitempty"`
+}
+
+// ForecastsResponse represents the response from /v1/forecasts/monthly.
+type ForecastsResponse struct {
+	Data ForecastsData `json:"data"`
+}
+
+// ForecastAccuracyStatistics contains aggregate accuracy statistics.
+type ForecastAccuracyStatistics struct {
+	SampleSize            int     `json:"sample_size"`
+	AvgMAPE1M             float64 `json:"avg_mape_1m"`
+	AvgMAPE3M             float64 `json:"avg_mape_3m"`
+	DirectionalAccuracy1M float64 `json:"directional_accuracy_1m"`
+	DirectionalAccuracy3M float64 `json:"directional_accuracy_3m"`
+}
+
+// ForecastAccuracyData contains the data from a forecast accuracy response.
+type ForecastAccuracyData struct {
+	LookbackMonths int                        `json:"lookback_months"`
+	Commodity      string                     `json:"commodity"`
+	Statistics     ForecastAccuracyStatistics `json:"statistics"`
+}
+
+// ForecastAccuracyResponse represents the response from /v1/forecasts/monthly/accuracy.
+type ForecastAccuracyResponse struct {
+	Data ForecastAccuracyData `json:"data"`
+}
+
+// ForecastsOptions contains options for forecast methods.
+type ForecastsOptions struct {
+	Commodity      string
+	LookbackMonths int
+}
+
+// ForecastsOption is a functional option for forecast methods.
+type ForecastsOption func(*ForecastsOptions)
+
+// WithForecastCommodity filters forecasts by commodity code.
+func WithForecastCommodity(code string) ForecastsOption {
+	return func(o *ForecastsOptions) {
+		o.Commodity = code
+	}
+}
+
+// WithLookbackMonths sets the accuracy lookback window in months (3-36).
+func WithLookbackMonths(months int) ForecastsOption {
+	return func(o *ForecastsOptions) {
+		o.LookbackMonths = months
+	}
+}
+
+// StorageLevel represents a single storage location's latest reading.
+type StorageLevel struct {
+	Code                string  `json:"code"`
+	Location            string  `json:"location"`
+	Value               float64 `json:"value"`
+	Units               string  `json:"units"`
+	CapacityUtilization float64 `json:"capacity_utilization"`
+	MarketSignal        string  `json:"market_signal,omitempty"`
+	DataDate            string  `json:"data_date"`
+	CreatedAt           string  `json:"created_at,omitempty"`
+}
+
+// StorageData contains the data from a storage list response.
+type StorageData struct {
+	Storage []StorageLevel `json:"storage"`
+}
+
+// StorageResponse represents the response from /v1/storage.
+type StorageResponse struct {
+	Status string      `json:"status"`
+	Data   StorageData `json:"data"`
+}
+
+// StorageHubCurrent contains the latest reading for a single storage hub.
+type StorageHubCurrent struct {
+	Value               float64 `json:"value"`
+	Units               string  `json:"units"`
+	CapacityUtilization float64 `json:"capacity_utilization"`
+	WeekOverWeekChange  float64 `json:"week_over_week_change"`
+	DataDate            string  `json:"data_date"`
+	CreatedAt           string  `json:"created_at,omitempty"`
+	UpdatedAt           string  `json:"updated_at,omitempty"`
+}
+
+// StorageHubAnalytics contains analytics for a single storage hub.
+type StorageHubAnalytics struct {
+	MarketSignal       string  `json:"market_signal,omitempty"`
+	TradingImplication string  `json:"trading_implication,omitempty"`
+	HistoricalAverage  float64 `json:"historical_average"`
+	Week52High         float64 `json:"week_52_high"`
+	Week52Low          float64 `json:"week_52_low"`
+	Trend              string  `json:"trend,omitempty"`
+}
+
+// StorageHubMetadata contains metadata for a single storage hub.
+type StorageHubMetadata struct {
+	Source              string  `json:"source,omitempty"`
+	UpdateFrequency     string  `json:"update_frequency,omitempty"`
+	OperationalCapacity float64 `json:"operational_capacity,omitempty"`
+	TotalCapacity       float64 `json:"total_capacity,omitempty"`
+}
+
+// StorageHub represents a detailed view of a single storage hub (Cushing, SPR).
+type StorageHub struct {
+	Current   StorageHubCurrent   `json:"current"`
+	Analytics StorageHubAnalytics `json:"analytics"`
+	Metadata  StorageHubMetadata  `json:"metadata"`
+}
+
+// StorageHubData contains the data from a single-hub storage response.
+type StorageHubData struct {
+	Storage StorageHub `json:"storage"`
+}
+
+// StorageHubResponse represents the response from /v1/storage/cushing and /v1/storage/spr.
+type StorageHubResponse struct {
+	Status string         `json:"status"`
+	Data   StorageHubData `json:"data"`
 }


### PR DESCRIPTION
Fixes compile-breaking README drift (wrong method names, positional futures args, invalid period values, phantom storage claim) and adds missing read endpoints: date-range historical (WithStartDate/WithEndDate), forecasts, and storage/inventories — with table-driven httptest coverage. go test -cover: 84.2%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forecasts API endpoints for commodity price predictions and accuracy metrics
  * Added storage API endpoints for tracking inventory levels across major storage hubs
  * Enhanced historical prices with custom date-range filtering and interval options

* **Documentation**
  * Updated API examples and reference guide with new endpoint usage patterns

* **Tests**
  * Added comprehensive test coverage for forecasts, storage, and enhanced historical price functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->