### PR TITLE
docs: normalize legacy plan names to current tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ fmt.Println(triggers.Message)
 ### Webhooks
 
 Beyond `ListWebhooks`, `CreateWebhook`, and `DeleteWebhook`, the SDK supports the
-full management lifecycle (Production Boost tier or higher).
+full management lifecycle (Starter plan ($49/mo) or higher).
 
 ```go
 // Get a single webhook (includes signing secret + available options)
@@ -344,7 +344,7 @@ for _, e := range events.Events {
 ### Analytics
 
 Advanced analytics: API usage performance, commodity correlation, trend
-analysis, and statistical forecasts (Production Boost / Reservoir Mastery tiers).
+analysis, and statistical forecasts (Professional+ / Scale tiers).
 
 ```go
 // API usage performance for the dashboard
@@ -386,13 +386,13 @@ Each response carries the dataset-specific payload as a raw JSON `Data` field
 ```go
 ei := client.EI()
 
-// EIA WPSR oil inventories (Reservoir Mastery)
+// EIA WPSR oil inventories (Professional+ / Scale)
 inv, err := ei.GetOilInventories(ctx)
 var invData map[string]interface{}
 _ = json.Unmarshal(inv.Data, &invData)
 fmt.Printf("source: %s, week ending: %v\n", inv.Meta.Source, invData["week_ending"])
 
-// OPEC MOMR production (Reservoir Mastery)
+// OPEC MOMR production (Professional+ / Scale)
 opec, err := ei.GetOpecProduction(ctx, oilpriceapi.WithEIMonths(12))
 
 // State well permits (well_permits addon / enterprise)

--- a/analytics.go
+++ b/analytics.go
@@ -105,7 +105,7 @@ func (c *Client) GetAnalyticsTrend(ctx context.Context, commodity string, opts .
 //
 // Use WithAnalyticsMethod to choose the forecast method (default "ema") and
 // WithAnalyticsPeriod to set the lookback window in days (default 90). This is a
-// Reservoir Mastery feature.
+// Professional+ / Scale feature.
 //
 // Example:
 //

--- a/ei.go
+++ b/ei.go
@@ -25,7 +25,7 @@ func (c *Client) EI() *EIClient {
 
 // GetOilInventories fetches the latest EIA WPSR oil-inventory report.
 //
-// Endpoint: GET /v1/ei/oil_inventories/latest. Requires Reservoir Mastery tier.
+// Endpoint: GET /v1/ei/oil_inventories/latest. Requires Professional+ / Scale tier.
 //
 // The Data field holds the raw report payload (its shape mirrors the API's
 // published report JSON); decode it into your own struct if you need typed
@@ -40,7 +40,7 @@ func (e *EIClient) GetOilInventories(ctx context.Context, opts ...EIOption) (*EI
 
 // GetOpecProduction fetches the latest OPEC MOMR production report.
 //
-// Endpoint: GET /v1/ei/opec_productions/latest. Requires Reservoir Mastery tier.
+// Endpoint: GET /v1/ei/opec_productions/latest. Requires Professional+ / Scale tier.
 func (e *EIClient) GetOpecProduction(ctx context.Context, opts ...EIOption) (*EIResponse, error) {
 	return e.get(ctx, "/v1/ei/opec_productions/latest", opts)
 }

--- a/errors.go
+++ b/errors.go
@@ -51,7 +51,7 @@ func (e *APIError) Error() string {
 }
 
 // StreamRejectedError is returned when the server rejects the WebSocket
-// subscription. Streaming requires a Reservoir Mastery (Professional+) plan and
+// subscription. Streaming requires a Professional+ plan ($99/mo) and
 // a valid API key; the server rejects the EnergyPricesChannel subscription
 // otherwise.
 type StreamRejectedError struct {
@@ -60,7 +60,7 @@ type StreamRejectedError struct {
 
 func (e *StreamRejectedError) Error() string {
 	if e.Message == "" {
-		return "stream subscription rejected: streaming requires a Reservoir Mastery (Professional+) plan and a valid API key"
+		return "stream subscription rejected: streaming requires a Professional+ plan ($99/mo) and a valid API key"
 	}
 	return fmt.Sprintf("stream subscription rejected: %s", e.Message)
 }

--- a/stream.go
+++ b/stream.go
@@ -223,7 +223,7 @@ func cableURL(baseURL string) string {
 
 // StreamPrices opens a real-time price stream over the EnergyPricesChannel.
 //
-// Streaming requires a Reservoir Mastery (Professional+) plan; the server
+// Streaming requires a Professional+ plan ($99/mo); the server
 // rejects the subscription otherwise, which surfaces as a *StreamRejectedError
 // on Err(). The supplied context controls the lifetime of the stream:
 // cancelling it (or calling Close) tears the connection down cleanly.

--- a/types.go
+++ b/types.go
@@ -1036,7 +1036,7 @@ type RigCount struct {
 	UpdatedAt string  `json:"updated_at"`
 }
 
-// RigCountUpdate is a rig-count update broadcast (drilling / Reservoir Mastery accounts).
+// RigCountUpdate is a rig-count update broadcast (drilling / Professional+ accounts).
 type RigCountUpdate struct {
 	Type      string   `json:"type"`
 	Timestamp string   `json:"timestamp"`


### PR DESCRIPTION
Replaces legacy tier names (**Reservoir Mastery**, **Production Boost**) in customer-facing doc comments, the README, and the `StreamRejectedError` message with current billing language (from `GET /billing/plans`).

## Tier mapping applied
- WebSocket/streaming -> **Professional+ plan ($99/mo)** (`stream.go`, `errors.go`, `types.go` rig-count comment)
- Webhooks -> **Starter plan ($49/mo) or higher** (`README.md` Webhooks section)
- Premium EI reports (oil inventories, OPEC) + analytics forecasts -> **Professional+ / Scale tiers** (`ei.go`, `analytics.go`, `README.md`)

## Note
The `StreamRejectedError` default message retains the literal `Professional+` token, so the existing `TestStream...` rejection assertion (`strings.Contains(err, "Professional+")`) still passes unchanged.

Comments/strings only; no functional code or endpoint paths changed. `go build`, `go vet`, and `go test ./...` all pass. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)