### PR TITLE
feat: market-brief + agent-subscription methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The official Go SDK for [OilPriceAPI](https://www.oilpriceapi.com) - Real-time a
 - **Automatic Retries** - Configurable retry with exponential backoff
 - **Real-Time Streaming** - WebSocket price streaming with auto-reconnect (Professional+)
 - **Minimal Dependencies** - Standard library only, plus `gorilla/websocket` for streaming
-- **Comprehensive Coverage** - Latest prices, historical data (fixed periods or custom date ranges), forecasts, futures, storage, rig counts, drilling, marine fuels, price alerts, webhooks (full CRUD), analytics, Energy Intelligence (oil inventories, OPEC production, well permits), and real-time streaming
+- **Comprehensive Coverage** - Latest prices, historical data (fixed periods or custom date ranges), forecasts, futures, storage, rig counts, drilling, marine fuels, price alerts, webhooks (full CRUD), analytics, market brief, agent subscriptions, Energy Intelligence (oil inventories, OPEC production, well permits), and real-time streaming
 
 ## Installation
 
@@ -400,6 +400,75 @@ permits, err := ei.GetWellPermits(ctx,
     oilpriceapi.WithEIDays(30),
     oilpriceapi.WithEIStates("TX,OK"),
 )
+```
+
+### Market Brief
+
+`GetMarketBrief` returns a multi-commodity structured summary (latest price, 24h
+change, freshness, spreads, and a 1-month forecast where available) for the
+requested codes in a single request. Codes accept the same shorthand as the rest
+of the API (e.g. `WTI`, `BRENT`). Pass `WithNarrative(true)` to additionally
+receive a deterministic narrative `Context` and `Summary`.
+
+```go
+brief, err := client.GetMarketBrief(ctx, []string{"BRENT_CRUDE_USD", "WTI_USD"})
+for _, c := range brief.Data.Commodities {
+    fmt.Printf("%s: %.2f %s (24h %.1f%%)\n", c.Code, c.Price, c.Currency, c.Change24hPct)
+}
+for _, s := range brief.Data.Spreads {
+    fmt.Printf("%s spread: %.2f %s\n", s.Label, s.Value, s.Currency)
+}
+
+// With narrative context + summary
+brief, err = client.GetMarketBrief(ctx, []string{"WTI_USD"}, oilpriceapi.WithNarrative(true))
+fmt.Println(brief.Data.Summary)
+```
+
+### Agent Subscriptions
+
+Agent subscriptions (watches) are persistent, server-side watches over a set of
+commodity codes, re-evaluated on a fixed interval. The poll endpoint
+(`GetSubscriptionEvents`) does **not** consume your monthly request quota, so
+agents can poll it frequently.
+
+Use `ParseInterval` to convert a friendly duration (`"5m"`, `"1h"`, or a plain
+number of seconds) to `IntervalSeconds`. `Source` and `ToolName` on the input are
+sent as the `X-OPA-Source` / `X-OPA-Tool` attribution headers; `Source` defaults
+to `"sdk-go"`.
+
+```go
+// List existing subscriptions
+subs, err := client.GetSubscriptions(ctx)
+
+// Create a subscription that re-evaluates every 5 minutes
+secs, _ := oilpriceapi.ParseInterval("5m") // 300
+created, err := client.CreateSubscription(ctx, oilpriceapi.SubscriptionInput{
+    Name:            "Crude watch",
+    Codes:           []string{"BRENT_CRUDE_USD", "WTI_USD"},
+    IntervalSeconds: secs,
+    Source:          "mcp",            // optional; sent as X-OPA-Source
+    ToolName:        "claude-desktop", // optional; sent as X-OPA-Tool
+})
+id := created.Data.Subscription.ID
+
+// Poll for events from a cursor (does not count against your quota)
+var cursor int64
+for {
+    events, err := client.GetSubscriptionEvents(ctx, oilpriceapi.WithSince(cursor))
+    if err != nil {
+        break
+    }
+    for _, e := range events.Data.Events {
+        fmt.Printf("seq=%d watch=%s deltas=%v\n", e.Seq, e.WatchID, e.Deltas)
+    }
+    cursor = events.Data.Cursor
+    if !events.Data.HasMore {
+        break
+    }
+}
+
+// Delete a subscription
+err = client.DeleteSubscription(ctx, id)
 ```
 
 ### Real-Time Streaming (WebSocket)

--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@ const (
 	// DefaultRetries is the default number of retries.
 	DefaultRetries = 3
 	// Version is the SDK version.
-	Version = "1.1.1"
+	Version = "1.2.0"
 )
 
 // futuresContractSlugs maps short futures contract codes to the API path slug
@@ -670,6 +670,14 @@ func (c *Client) handleError(resp *http.Response) error {
 
 // doRequest makes an authenticated request with retry logic.
 func (c *Client) doRequest(ctx context.Context, method, endpoint string, body io.Reader) (*http.Response, error) {
+	return c.doRequestWithHeaders(ctx, method, endpoint, body, nil)
+}
+
+// doRequestWithHeaders is doRequest with additional per-request headers (e.g.
+// the X-OPA-Source / X-OPA-Tool attribution headers used by subscriptions).
+// The extra headers are applied after the common headers, so they take
+// precedence.
+func (c *Client) doRequestWithHeaders(ctx context.Context, method, endpoint string, body io.Reader, headers map[string]string) (*http.Response, error) {
 	var lastErr error
 
 	for attempt := 0; attempt <= c.retries; attempt++ {
@@ -685,6 +693,9 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, body io
 		}
 
 		c.setHeaders(req)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {

--- a/live_test.go
+++ b/live_test.go
@@ -122,3 +122,47 @@ func TestLiveGetFuturesCurve(t *testing.T) {
 		t.Error("curve returned neither contract data nor a documented no-data error")
 	}
 }
+
+// TestLiveGetMarketBrief verifies the live /v1/market-brief endpoint (#3245
+// Phase 1a) returns a 200 with a sane Brent spot price.
+func TestLiveGetMarketBrief(t *testing.T) {
+	client := liveClient(t)
+	ctx := context.Background()
+
+	liveRateLimit()
+
+	resp, err := client.GetMarketBrief(ctx, []string{"BRENT_CRUDE_USD"})
+	if err != nil {
+		t.Fatalf("GetMarketBrief(BRENT_CRUDE_USD) returned error: %v", err)
+	}
+	if resp == nil || resp.Status != "success" {
+		t.Fatalf("expected success status, got %+v", resp)
+	}
+	if len(resp.Data.Commodities) == 0 {
+		t.Fatal("expected at least one commodity in the brief")
+	}
+	price := resp.Data.Commodities[0].Price
+	if price <= 0 || price > 1000 {
+		t.Errorf("Brent brief price %.2f is outside a sane range", price)
+	}
+}
+
+// TestLiveGetSubscriptions verifies the live /v1/subscriptions list endpoint
+// (#3245 Phase 2) returns a 200. It performs a read only — no writes.
+func TestLiveGetSubscriptions(t *testing.T) {
+	client := liveClient(t)
+	ctx := context.Background()
+
+	liveRateLimit()
+
+	resp, err := client.GetSubscriptions(ctx)
+	if err != nil {
+		t.Fatalf("GetSubscriptions returned error: %v", err)
+	}
+	if resp == nil || resp.Status != "success" {
+		t.Fatalf("expected success status, got %+v", resp)
+	}
+	// The subscriptions list may legitimately be empty for the test account;
+	// a 200 with a (possibly empty) slice is the success condition.
+	t.Logf("account has %d subscription(s)", len(resp.Data.Subscriptions))
+}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -1,0 +1,251 @@
+package oilpriceapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultSubscriptionSource is the attribution source sent as the X-OPA-Source
+// header when a SubscriptionInput does not set one explicitly.
+const DefaultSubscriptionSource = "sdk-go"
+
+// GetMarketBrief fetches a multi-commodity structured market summary for the
+// given commodity codes (#3245 Phase 1a).
+//
+// Codes accept the same shorthand the rest of the API does (e.g. "WTI",
+// "BRENT"); the server alias-resolves them to canonical codes. Pass
+// WithNarrative(true) to additionally receive the deterministic narrative
+// context and summary.
+//
+// Example:
+//
+//	brief, err := client.GetMarketBrief(ctx, []string{"BRENT_CRUDE_USD", "WTI_USD"})
+//	for _, c := range brief.Data.Commodities {
+//	    fmt.Printf("%s: %.2f %s\n", c.Code, c.Price, c.Currency)
+//	}
+//
+//	// With narrative context + summary
+//	brief, err := client.GetMarketBrief(ctx, []string{"WTI_USD"}, oilpriceapi.WithNarrative(true))
+func (c *Client) GetMarketBrief(ctx context.Context, codes []string, opts ...MarketBriefOption) (*MarketBriefResponse, error) {
+	if len(codes) == 0 {
+		return nil, fmt.Errorf("codes is required: pass at least one commodity code")
+	}
+
+	options := &MarketBriefOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	query := url.Values{}
+	query.Set("codes", strings.Join(codes, ","))
+	if options.Narrative {
+		query.Set("narrative", "true")
+	}
+
+	endpoint := "/v1/market-brief?" + query.Encode()
+
+	resp, err := c.doRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var result MarketBriefResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetSubscriptions lists the caller's agent subscriptions (watches), newest
+// first (#3245 Phase 2).
+//
+// Example:
+//
+//	subs, err := client.GetSubscriptions(ctx)
+//	for _, s := range subs.Data.Subscriptions {
+//	    fmt.Printf("%s watches %v every %ds\n", s.Name, s.Codes, s.IntervalSeconds)
+//	}
+func (c *Client) GetSubscriptions(ctx context.Context) (*SubscriptionsResponse, error) {
+	resp, err := c.doRequest(ctx, "GET", "/v1/subscriptions", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var result SubscriptionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateSubscription creates a new agent subscription (watch).
+//
+// The input's Source and ToolName are sent as the X-OPA-Source and X-OPA-Tool
+// attribution headers rather than in the JSON body; Source defaults to
+// DefaultSubscriptionSource ("sdk-go") when blank. Set IntervalSeconds directly,
+// or convert a friendly duration with ParseInterval ("5m", "1h").
+//
+// Example:
+//
+//	secs, _ := oilpriceapi.ParseInterval("5m")
+//	sub, err := client.CreateSubscription(ctx, oilpriceapi.SubscriptionInput{
+//	    Name:            "Crude watch",
+//	    Codes:           []string{"BRENT_CRUDE_USD", "WTI_USD"},
+//	    IntervalSeconds: secs,
+//	})
+func (c *Client) CreateSubscription(ctx context.Context, input SubscriptionInput) (*SubscriptionResponse, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+
+	source := input.Source
+	if source == "" {
+		source = DefaultSubscriptionSource
+	}
+
+	headers := map[string]string{"X-OPA-Source": source}
+	if input.ToolName != "" {
+		headers["X-OPA-Tool"] = input.ToolName
+	}
+
+	resp, err := c.doRequestWithHeaders(ctx, "POST", "/v1/subscriptions", bytes.NewReader(body), headers)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, c.handleError(resp)
+	}
+
+	var result SubscriptionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteSubscription deletes a subscription by ID. The endpoint returns 204 No
+// Content on success.
+func (c *Client) DeleteSubscription(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("id is required")
+	}
+
+	resp, err := c.doRequest(ctx, "DELETE", "/v1/subscriptions/"+url.PathEscape(id), nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return c.handleError(resp)
+	}
+	return nil
+}
+
+// GetSubscriptionEvents polls the per-user event cursor (#3245 Phase 2). This
+// endpoint does NOT consume the monthly request quota, so agents may poll it
+// frequently.
+//
+// Pass WithSince(cursor) to page forward from a previous response, WithEventLimit
+// to cap the page size, and WithEventWatchID to scope to a single subscription.
+//
+// Example:
+//
+//	events, err := client.GetSubscriptionEvents(ctx, oilpriceapi.WithSince(lastCursor))
+//	for _, e := range events.Data.Events {
+//	    fmt.Printf("seq=%d watch=%s\n", e.Seq, e.WatchID)
+//	}
+//	lastCursor = events.Data.Cursor
+func (c *Client) GetSubscriptionEvents(ctx context.Context, opts ...EventOption) (*SubscriptionEventsResponse, error) {
+	options := &EventsOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	query := url.Values{}
+	if options.sinceSet {
+		query.Set("since", strconv.FormatInt(options.Since, 10))
+	}
+	if options.Limit > 0 {
+		query.Set("limit", strconv.Itoa(options.Limit))
+	}
+	if options.WatchID != "" {
+		query.Set("watch_id", options.WatchID)
+	}
+
+	endpoint := "/v1/subscriptions/events"
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+
+	resp, err := c.doRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var result SubscriptionEventsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ParseInterval converts a friendly interval string to whole seconds for use as
+// SubscriptionInput.IntervalSeconds.
+//
+// It accepts a Go duration string ("5m", "1h", "30s", "90m") as well as a plain
+// integer interpreted as seconds ("300"). The result is rounded to whole
+// seconds. An empty or unparseable value returns an error.
+//
+// Example:
+//
+//	secs, err := oilpriceapi.ParseInterval("5m") // 300
+func ParseInterval(interval string) (int, error) {
+	s := strings.TrimSpace(interval)
+	if s == "" {
+		return 0, fmt.Errorf("interval is empty")
+	}
+
+	// Plain integer => seconds.
+	if n, err := strconv.Atoi(s); err == nil {
+		if n <= 0 {
+			return 0, fmt.Errorf("interval %q must be positive", interval)
+		}
+		return n, nil
+	}
+
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid interval %q: use a duration like \"5m\"/\"1h\" or a number of seconds", interval)
+	}
+	secs := int(d.Round(time.Second) / time.Second)
+	if secs <= 0 {
+		return 0, fmt.Errorf("interval %q must be positive", interval)
+	}
+	return secs, nil
+}

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -1,0 +1,490 @@
+package oilpriceapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ===================
+// MARKET BRIEF
+// ===================
+
+func TestGetMarketBrief(t *testing.T) {
+	tests := []struct {
+		name          string
+		codes         []string
+		opts          []MarketBriefOption
+		wantCodesArg  string
+		wantNarrative string // "" means narrative param must be absent
+	}{
+		{
+			name:          "single code, no narrative",
+			codes:         []string{"BRENT_CRUDE_USD"},
+			wantCodesArg:  "BRENT_CRUDE_USD",
+			wantNarrative: "",
+		},
+		{
+			name:          "multiple codes joined with comma",
+			codes:         []string{"BRENT_CRUDE_USD", "WTI_USD"},
+			wantCodesArg:  "BRENT_CRUDE_USD,WTI_USD",
+			wantNarrative: "",
+		},
+		{
+			name:          "narrative requested",
+			codes:         []string{"WTI_USD"},
+			opts:          []MarketBriefOption{WithNarrative(true)},
+			wantCodesArg:  "WTI_USD",
+			wantNarrative: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/market-brief" {
+					t.Errorf("expected path /v1/market-brief, got %s", r.URL.Path)
+				}
+				if got := r.URL.Query().Get("codes"); got != tt.wantCodesArg {
+					t.Errorf("expected codes=%q, got %q", tt.wantCodesArg, got)
+				}
+				if got := r.URL.Query().Get("narrative"); got != tt.wantNarrative {
+					t.Errorf("expected narrative=%q, got %q", tt.wantNarrative, got)
+				}
+				if r.Header.Get("Authorization") != "Token test-key" {
+					t.Errorf("expected auth header, got %q", r.Header.Get("Authorization"))
+				}
+
+				resp := MarketBriefResponse{
+					Status: "success",
+					Data: MarketBrief{
+						AsOf:  "2026-06-21T00:00:00Z",
+						Codes: tt.codes,
+						Commodities: []MarketBriefCommodity{
+							{
+								Code:         "BRENT_CRUDE_USD",
+								Name:         "Brent Crude Oil",
+								Price:        78.42,
+								Currency:     "USD",
+								Unit:         "barrel",
+								Change24hPct: 1.2,
+								Stale:        false,
+								Forecast1M:   &MarketBriefForecast{Point: 80.1, Low: 76.0, High: 84.2, Confidence: 0.7},
+							},
+						},
+						Spreads: []MarketBriefSpread{
+							{Pair: "BRENT_CRUDE_USD-WTI_USD", Label: "Brent-WTI", Value: 6.08, Currency: "USD"},
+						},
+					},
+				}
+				if tt.wantNarrative == "true" {
+					resp.Data.Summary = "Brent is up 1.2% at $78.42."
+					resp.Data.Context = &MarketBriefContext{
+						TopIndicators: []MarketBriefIndicator{{Code: "DXY", Value: 104.2, ChangePct: -0.3}},
+					}
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			client := NewClient("test-key", WithBaseURL(server.URL))
+			got, err := client.GetMarketBrief(context.Background(), tt.codes, tt.opts...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Status != "success" {
+				t.Errorf("expected status success, got %s", got.Status)
+			}
+			if len(got.Data.Commodities) != 1 {
+				t.Fatalf("expected 1 commodity, got %d", len(got.Data.Commodities))
+			}
+			c := got.Data.Commodities[0]
+			if c.Price != 78.42 {
+				t.Errorf("expected price 78.42, got %v", c.Price)
+			}
+			if c.Forecast1M == nil || c.Forecast1M.Point != 80.1 {
+				t.Errorf("expected forecast point 80.1, got %+v", c.Forecast1M)
+			}
+			if tt.wantNarrative == "true" {
+				if got.Data.Summary == "" {
+					t.Error("expected non-empty summary when narrative requested")
+				}
+				if got.Data.Context == nil || len(got.Data.Context.TopIndicators) == 0 {
+					t.Error("expected narrative context with indicators")
+				}
+			} else if got.Data.Context != nil {
+				t.Error("expected no context when narrative not requested")
+			}
+		})
+	}
+}
+
+func TestGetMarketBriefValidation(t *testing.T) {
+	client := NewClient("test-key")
+	if _, err := client.GetMarketBrief(context.Background(), nil); err == nil {
+		t.Error("expected error for empty codes")
+	}
+}
+
+func TestGetMarketBriefServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient("bad-key", WithBaseURL(server.URL))
+	_, err := client.GetMarketBrief(context.Background(), []string{"WTI_USD"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if _, ok := err.(*AuthenticationError); !ok {
+		t.Errorf("expected *AuthenticationError, got %T", err)
+	}
+}
+
+// ===================
+// SUBSCRIPTIONS LIST
+// ===================
+
+func TestGetSubscriptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/subscriptions" {
+			t.Errorf("expected /v1/subscriptions, got %s", r.URL.Path)
+		}
+		resp := SubscriptionsResponse{
+			Status: "success",
+			Data: SubscriptionsData{
+				Subscriptions: []Subscription{
+					{
+						ID:              "11111111-1111-1111-1111-111111111111",
+						Name:            "Crude watch",
+						Codes:           []string{"BRENT_CRUDE_USD", "WTI_USD"},
+						IntervalSeconds: 300,
+						Status:          "active",
+						Source:          "sdk-go",
+					},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	got, err := client.GetSubscriptions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Data.Subscriptions) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(got.Data.Subscriptions))
+	}
+	s := got.Data.Subscriptions[0]
+	if s.Name != "Crude watch" || s.IntervalSeconds != 300 {
+		t.Errorf("unexpected subscription: %+v", s)
+	}
+	if len(s.Codes) != 2 {
+		t.Errorf("expected 2 codes, got %d", len(s.Codes))
+	}
+}
+
+// ===================
+// SUBSCRIPTION CREATE
+// ===================
+
+func TestCreateSubscription(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          SubscriptionInput
+		wantSource     string
+		wantTool       string // "" means header must be absent
+		wantStatusCode int
+	}{
+		{
+			name: "defaults source to sdk-go",
+			input: SubscriptionInput{
+				Name:            "Crude watch",
+				Codes:           []string{"BRENT_CRUDE_USD"},
+				IntervalSeconds: 300,
+			},
+			wantSource:     "sdk-go",
+			wantTool:       "",
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "explicit source and tool sent as headers",
+			input: SubscriptionInput{
+				Name:            "MCP watch",
+				Codes:           []string{"WTI_USD"},
+				IntervalSeconds: 600,
+				Source:          "mcp",
+				ToolName:        "claude-desktop",
+			},
+			wantSource:     "mcp",
+			wantTool:       "claude-desktop",
+			wantStatusCode: http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if got := r.Header.Get("X-OPA-Source"); got != tt.wantSource {
+					t.Errorf("expected X-OPA-Source=%q, got %q", tt.wantSource, got)
+				}
+				if got := r.Header.Get("X-OPA-Tool"); got != tt.wantTool {
+					t.Errorf("expected X-OPA-Tool=%q, got %q", tt.wantTool, got)
+				}
+
+				// Verify body has codes + interval and does NOT leak source/tool.
+				body, _ := io.ReadAll(r.Body)
+				var sent map[string]interface{}
+				if err := json.Unmarshal(body, &sent); err != nil {
+					t.Fatalf("bad request body: %v", err)
+				}
+				if _, leaked := sent["source"]; leaked {
+					t.Error("source should not appear in JSON body")
+				}
+				if _, leaked := sent["tool_name"]; leaked {
+					t.Error("tool_name should not appear in JSON body")
+				}
+				if _, ok := sent["codes"]; !ok {
+					t.Error("expected codes in body")
+				}
+
+				w.WriteHeader(tt.wantStatusCode)
+				_ = json.NewEncoder(w).Encode(SubscriptionResponse{
+					Status: "success",
+					Data: SubscriptionData{
+						Subscription: Subscription{
+							ID:              "22222222-2222-2222-2222-222222222222",
+							Name:            tt.input.Name,
+							Codes:           tt.input.Codes,
+							IntervalSeconds: tt.input.IntervalSeconds,
+							Status:          "active",
+							Source:          tt.wantSource,
+							ToolName:        tt.wantTool,
+						},
+					},
+				})
+			}))
+			defer server.Close()
+
+			client := NewClient("test-key", WithBaseURL(server.URL))
+			got, err := client.CreateSubscription(context.Background(), tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Data.Subscription.ID == "" {
+				t.Error("expected subscription ID in response")
+			}
+			if got.Data.Subscription.Name != tt.input.Name {
+				t.Errorf("expected name %q, got %q", tt.input.Name, got.Data.Subscription.Name)
+			}
+		})
+	}
+}
+
+// ===================
+// SUBSCRIPTION DELETE
+// ===================
+
+func TestDeleteSubscription(t *testing.T) {
+	t.Run("204 no content success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				t.Errorf("expected DELETE, got %s", r.Method)
+			}
+			if r.URL.Path != "/v1/subscriptions/abc-123" {
+				t.Errorf("unexpected path %s", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		if err := client.DeleteSubscription(context.Background(), "abc-123"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty id errors without request", func(t *testing.T) {
+		client := NewClient("test-key")
+		if err := client.DeleteSubscription(context.Background(), ""); err == nil {
+			t.Error("expected error for empty id")
+		}
+	})
+
+	t.Run("not found returns typed error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		err := client.DeleteSubscription(context.Background(), "missing")
+		if _, ok := err.(*NotFoundError); !ok {
+			t.Errorf("expected *NotFoundError, got %T", err)
+		}
+	})
+}
+
+// ===================
+// SUBSCRIPTION EVENTS
+// ===================
+
+func TestGetSubscriptionEvents(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      []EventOption
+		wantQuery string
+	}{
+		{
+			name:      "no options sends no query",
+			opts:      nil,
+			wantQuery: "",
+		},
+		{
+			name:      "since cursor",
+			opts:      []EventOption{WithSince(42)},
+			wantQuery: "since=42",
+		},
+		{
+			name:      "since zero is still sent",
+			opts:      []EventOption{WithSince(0)},
+			wantQuery: "since=0",
+		},
+		{
+			name:      "limit and watch id",
+			opts:      []EventOption{WithEventLimit(10), WithEventWatchID("w-1")},
+			wantQuery: "limit=10&watch_id=w-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/subscriptions/events" {
+					t.Errorf("unexpected path %s", r.URL.Path)
+				}
+				if got := r.URL.RawQuery; got != tt.wantQuery {
+					t.Errorf("expected query %q, got %q", tt.wantQuery, got)
+				}
+				_ = json.NewEncoder(w).Encode(SubscriptionEventsResponse{
+					Status: "success",
+					Data: SubscriptionEventsData{
+						Cursor:  99,
+						HasMore: true,
+						Events: []SubscriptionEvent{
+							{
+								ID:       1,
+								Seq:      99,
+								WatchID:  "w-1",
+								Snapshot: map[string]interface{}{"BRENT_CRUDE_USD": 78.4},
+								Deltas:   map[string]interface{}{"BRENT_CRUDE_USD": 1.2},
+								Source:   "sdk-go",
+							},
+						},
+					},
+				})
+			}))
+			defer server.Close()
+
+			client := NewClient("test-key", WithBaseURL(server.URL))
+			got, err := client.GetSubscriptionEvents(context.Background(), tt.opts...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Data.Cursor != 99 {
+				t.Errorf("expected cursor 99, got %d", got.Data.Cursor)
+			}
+			if !got.Data.HasMore {
+				t.Error("expected has_more true")
+			}
+			if len(got.Data.Events) != 1 || got.Data.Events[0].Seq != 99 {
+				t.Errorf("unexpected events: %+v", got.Data.Events)
+			}
+		})
+	}
+}
+
+// ===================
+// INTERVAL HELPER
+// ===================
+
+func TestParseInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{name: "minutes", in: "5m", want: 300},
+		{name: "hour", in: "1h", want: 3600},
+		{name: "seconds suffix", in: "30s", want: 30},
+		{name: "compound", in: "1h30m", want: 5400},
+		{name: "plain integer seconds", in: "300", want: 300},
+		{name: "whitespace trimmed", in: "  10m  ", want: 600},
+		{name: "empty errors", in: "", wantErr: true},
+		{name: "garbage errors", in: "abc", wantErr: true},
+		{name: "zero errors", in: "0", wantErr: true},
+		{name: "negative errors", in: "-5", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseInterval(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got %d", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseInterval(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCreateSubscriptionWithParsedInterval exercises the documented
+// ParseInterval -> IntervalSeconds flow end to end.
+func TestCreateSubscriptionWithParsedInterval(t *testing.T) {
+	secs, err := ParseInterval("5m")
+	if err != nil {
+		t.Fatalf("ParseInterval failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"interval_seconds":300`) {
+			t.Errorf("expected interval_seconds:300 in body, got %s", string(body))
+		}
+		_ = json.NewEncoder(w).Encode(SubscriptionResponse{Status: "success"})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL))
+	_, err = client.CreateSubscription(context.Background(), SubscriptionInput{
+		Name:            "x",
+		Codes:           []string{"WTI_USD"},
+		IntervalSeconds: secs,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -1060,3 +1060,226 @@ type Update struct {
 	// Raw is the undecoded channel message payload (always set).
 	Raw json.RawMessage
 }
+
+// =============================================================================
+// MARKET BRIEF (#3245 Phase 1a) — GET /v1/market-brief
+// =============================================================================
+
+// MarketBriefForecast is the optional 1-month forecast attached to a commodity
+// in a market brief. It is only present for commodities the forecast model
+// covers (WTI, Brent, Natural Gas) and only when the data is available; any
+// individual bound may be zero when the server omits it.
+type MarketBriefForecast struct {
+	Point      float64 `json:"point,omitempty"`
+	Low        float64 `json:"low,omitempty"`
+	High       float64 `json:"high,omitempty"`
+	Confidence float64 `json:"confidence,omitempty"`
+}
+
+// MarketBriefCommodity is a single commodity entry in a market brief. It
+// composes the latest spot price, the 24h change, freshness, and (when
+// available) the 1-month forecast.
+type MarketBriefCommodity struct {
+	Code         string               `json:"code"`
+	Name         string               `json:"name"`
+	Price        float64              `json:"price"`
+	Currency     string               `json:"currency"`
+	Unit         string               `json:"unit,omitempty"`
+	Change24hPct float64              `json:"change_24h_pct,omitempty"`
+	Change24hAbs float64              `json:"change_24h_abs,omitempty"`
+	AsOf         string               `json:"as_of,omitempty"`
+	Source       string               `json:"source,omitempty"`
+	Stale        bool                 `json:"stale"`
+	Forecast1M   *MarketBriefForecast `json:"forecast_1m,omitempty"`
+}
+
+// MarketBriefSpread is a commodity spread (e.g. Brent-WTI) surfaced when both
+// legs are present in the requested codes.
+type MarketBriefSpread struct {
+	Pair     string  `json:"pair"`
+	Label    string  `json:"label"`
+	Value    float64 `json:"value"`
+	Currency string  `json:"currency"`
+}
+
+// MarketBriefDisruption is a single active supply disruption included in the
+// narrative context (only present when narrative is requested).
+type MarketBriefDisruption struct {
+	Title    string `json:"title"`
+	Severity string `json:"severity"`
+	Region   string `json:"region,omitempty"`
+}
+
+// MarketBriefIndicator is a single economic indicator included in the narrative
+// context (only present when narrative is requested).
+type MarketBriefIndicator struct {
+	Code      string  `json:"code"`
+	Value     float64 `json:"value"`
+	ChangePct float64 `json:"change_pct,omitempty"`
+}
+
+// MarketBriefContext is the optional narrative context block, present only when
+// the brief was requested with WithNarrative(true).
+type MarketBriefContext struct {
+	Disruptions   []MarketBriefDisruption `json:"disruptions,omitempty"`
+	TopIndicators []MarketBriefIndicator  `json:"top_indicators,omitempty"`
+}
+
+// MarketBrief is the data payload of a /v1/market-brief response. Context and
+// Summary are only populated when the brief is requested with narrative
+// enabled.
+type MarketBrief struct {
+	AsOf        string                 `json:"as_of"`
+	Codes       []string               `json:"codes"`
+	Commodities []MarketBriefCommodity `json:"commodities"`
+	Spreads     []MarketBriefSpread    `json:"spreads,omitempty"`
+	Context     *MarketBriefContext    `json:"context,omitempty"`
+	Summary     string                 `json:"summary,omitempty"`
+}
+
+// MarketBriefResponse is the full envelope returned by GET /v1/market-brief.
+type MarketBriefResponse struct {
+	Status string      `json:"status"`
+	Data   MarketBrief `json:"data"`
+}
+
+// MarketBriefOptions contains options for GetMarketBrief.
+type MarketBriefOptions struct {
+	Narrative bool
+}
+
+// MarketBriefOption is a functional option for GetMarketBrief.
+type MarketBriefOption func(*MarketBriefOptions)
+
+// WithNarrative requests the optional narrative context and summary fields in
+// the market brief. When omitted, only the structured commodity data is
+// returned.
+func WithNarrative(narrative bool) MarketBriefOption {
+	return func(o *MarketBriefOptions) {
+		o.Narrative = narrative
+	}
+}
+
+// =============================================================================
+// AGENT SUBSCRIPTIONS (#3245 Phase 2) — /v1/subscriptions
+// =============================================================================
+
+// Subscription is a persistent agent "watch" — a saved set of commodity codes
+// the platform re-evaluates on a fixed interval, emitting events when prices
+// move. It is returned by the subscription CRUD endpoints.
+type Subscription struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	Codes           []string `json:"codes"`
+	IntervalSeconds int      `json:"interval_seconds"`
+	Status          string   `json:"status"`
+	DeliverWebhook  bool     `json:"deliver_webhook"`
+	Source          string   `json:"source,omitempty"`
+	ToolName        string   `json:"tool_name,omitempty"`
+	LastEvaluatedAt string   `json:"last_evaluated_at,omitempty"`
+	NextRunAt       string   `json:"next_run_at,omitempty"`
+	CreatedAt       string   `json:"created_at,omitempty"`
+}
+
+// SubscriptionsData is the data payload of a list-subscriptions response.
+type SubscriptionsData struct {
+	Subscriptions []Subscription `json:"subscriptions"`
+}
+
+// SubscriptionsResponse is the envelope returned by GET /v1/subscriptions.
+type SubscriptionsResponse struct {
+	Status string            `json:"status"`
+	Data   SubscriptionsData `json:"data"`
+}
+
+// SubscriptionData is the data payload of a single-subscription response
+// (create/show/update), which nests the watch under "subscription".
+type SubscriptionData struct {
+	Subscription Subscription `json:"subscription"`
+}
+
+// SubscriptionResponse is the envelope returned by POST /v1/subscriptions.
+type SubscriptionResponse struct {
+	Status string           `json:"status"`
+	Data   SubscriptionData `json:"data"`
+}
+
+// SubscriptionInput contains the parameters for creating a subscription.
+//
+// Provide IntervalSeconds directly, or use WithInterval on the input via the
+// IntervalString helper to convert a friendly duration ("5m", "1h") to seconds.
+// Source and ToolName are sent as the X-OPA-Source / X-OPA-Tool attribution
+// headers (Source defaults to "sdk-go" when left blank).
+type SubscriptionInput struct {
+	Name            string   `json:"name"`
+	Codes           []string `json:"codes"`
+	IntervalSeconds int      `json:"interval_seconds,omitempty"`
+	DeliverWebhook  bool     `json:"deliver_webhook,omitempty"`
+
+	// Source and ToolName are attribution metadata sent as request headers, not
+	// in the JSON body. They are excluded from the marshaled request body.
+	Source   string `json:"-"`
+	ToolName string `json:"-"`
+}
+
+// SubscriptionEvent is a single watch event returned by the poll endpoint. It
+// carries a monotonically increasing per-user Seq cursor, the observed price
+// Snapshot, and the Deltas that triggered the event.
+type SubscriptionEvent struct {
+	ID         int64                  `json:"id"`
+	Seq        int64                  `json:"seq"`
+	WatchID    string                 `json:"watch_id"`
+	ObservedAt string                 `json:"observed_at,omitempty"`
+	Snapshot   map[string]interface{} `json:"snapshot,omitempty"`
+	Deltas     map[string]interface{} `json:"deltas,omitempty"`
+	Source     string                 `json:"source,omitempty"`
+	ToolName   string                 `json:"tool_name,omitempty"`
+}
+
+// SubscriptionEventsData is the data payload of a poll-events response.
+type SubscriptionEventsData struct {
+	Cursor  int64               `json:"cursor"`
+	HasMore bool                `json:"has_more"`
+	Events  []SubscriptionEvent `json:"events"`
+}
+
+// SubscriptionEventsResponse is the envelope returned by
+// GET /v1/subscriptions/events.
+type SubscriptionEventsResponse struct {
+	Status string                 `json:"status"`
+	Data   SubscriptionEventsData `json:"data"`
+}
+
+// EventsOptions contains options for GetSubscriptionEvents.
+type EventsOptions struct {
+	Since    int64
+	sinceSet bool
+	Limit    int
+	WatchID  string
+}
+
+// EventOption is a functional option for GetSubscriptionEvents.
+type EventOption func(*EventsOptions)
+
+// WithSince sets the cursor: only events with seq greater than this value are
+// returned. Pass the cursor from the previous response to page forward.
+func WithSince(seq int64) EventOption {
+	return func(o *EventsOptions) {
+		o.Since = seq
+		o.sinceSet = true
+	}
+}
+
+// WithEventLimit caps the number of events returned (server clamps to 1..500).
+func WithEventLimit(limit int) EventOption {
+	return func(o *EventsOptions) {
+		o.Limit = limit
+	}
+}
+
+// WithEventWatchID restricts the poll to events from a single subscription.
+func WithEventWatchID(watchID string) EventOption {
+	return func(o *EventsOptions) {
+		o.WatchID = watchID
+	}
+}


### PR DESCRIPTION
Adds Go SDK methods for the now-live #3245 endpoints (market brief + agent subscriptions), bringing the Go SDK to parity with the live API. Version bumped to **1.2.0** (release tag intentionally **not** cut in this PR).

## Methods added

**Market brief** (`/v1/market-brief`)
- `GetMarketBrief(ctx, codes []string, ...MarketBriefOption)` → `*MarketBriefResponse`
  - `WithNarrative(bool)` opts into the narrative `Context` + `Summary` block

**Agent subscriptions** (`/v1/subscriptions`)
- `GetSubscriptions(ctx)` → list watches
- `CreateSubscription(ctx, SubscriptionInput)` → create
- `DeleteSubscription(ctx, id)` → delete (handles 204)
- `GetSubscriptionEvents(ctx, ...EventOption)` → poll cursor; `WithSince`, `WithEventLimit`, `WithEventWatchID`
- `ParseInterval("5m"/"1h"/"300")` → seconds helper for `IntervalSeconds`
- `SubscriptionInput.Source` / `.ToolName` are sent as `X-OPA-Source` / `X-OPA-Tool` attribution headers (not in the JSON body); `Source` defaults to `sdk-go`. Implemented via a new internal `doRequestWithHeaders` that `doRequest` now delegates to (identical retry behavior).

**Types** (in `types.go`): `MarketBrief`, `MarketBriefCommodity`, `MarketBriefForecast`, `MarketBriefSpread`, `MarketBriefContext`, `Subscription`, `SubscriptionEvent`, and `{status,data}` response wrappers matching the real envelope (`render_success` → `{status:"success", data:{...}}`; single-subscription responses nest under `data.subscription`).

## Tests

Table-driven `httptest` mock tests for every method, header attribution, body-leak guards (source/tool not in JSON), DELETE 204/404, event query construction, and the full `ParseInterval` matrix. Live read tests (`//go:build live`) for `GetMarketBrief(BRENT_CRUDE_USD)` and `GetSubscriptions` that `t.Skip` when `OILPRICEAPI_TEST_KEY` is unset; no prod writes.

**Live-test result:** SKIPPED — `OILPRICEAPI_TEST_KEY` was not available in the build environment, so the live tests skipped as designed (they pass-by-skip and do not fail CI without a key).

## Gates

- `go build ./...` ✅
- `go vet ./...` and `go vet -tags live ./...` ✅
- `gofmt -l .` clean ✅
- `go test -cover ./...` ✅ **85.5%** (≥80%); per-method: GetMarketBrief 90%, GetSubscriptions 70%, CreateSubscription 79%, DeleteSubscription 89%, GetSubscriptionEvents 87%, ParseInterval 93%
- README documents both new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)