### PR TITLE
ci: skip live tests on 429 (shared-key rate-limit resilience)

### DIFF
--- a/live_test.go
+++ b/live_test.go
@@ -15,6 +15,7 @@ package oilpriceapi
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -36,6 +37,22 @@ func liveRateLimit() {
 	time.Sleep(1100 * time.Millisecond)
 }
 
+// skipIfRateLimited turns an HTTP 429 (*RateLimitError) from a live API call
+// into a t.Skip instead of a failure. The CI key is shared at ~1 req/sec across
+// repos, so cross-repo contention can return 429 even when the SDK code is
+// correct — that should not red-flag a green change. Returns true (and skips)
+// when err is a rate-limit error; returns false otherwise so callers can fall
+// through to their normal assertions.
+func skipIfRateLimited(t *testing.T, err error) bool {
+	t.Helper()
+	var rle *RateLimitError
+	if errors.As(err, &rle) {
+		t.Skip("rate-limited (shared CI key) — skipping live assertion")
+		return true
+	}
+	return false
+}
+
 // TestLiveGetFuturesLatest verifies that the corrected /v1/futures/{slug} path
 // returns a 200 with a sane Brent price. This is the regression guard for the
 // v1.1.0 bug where the SDK hit /v1/futures/latest?contract=BZ (404).
@@ -44,6 +61,9 @@ func TestLiveGetFuturesLatest(t *testing.T) {
 	ctx := context.Background()
 
 	resp, err := client.GetFuturesLatest(ctx, WithContract("ice-brent"))
+	if skipIfRateLimited(t, err) {
+		return
+	}
 	if err != nil {
 		t.Fatalf("GetFuturesLatest(ice-brent) returned error (path regression?): %v", err)
 	}
@@ -84,6 +104,9 @@ func TestLiveGetFuturesLatestByCode(t *testing.T) {
 	liveRateLimit()
 
 	resp, err := client.GetFuturesLatest(ctx, WithContract("CL"))
+	if skipIfRateLimited(t, err) {
+		return
+	}
 	if err != nil {
 		t.Fatalf("GetFuturesLatest(CL) returned error: %v", err)
 	}
@@ -103,6 +126,9 @@ func TestLiveGetFuturesCurve(t *testing.T) {
 	liveRateLimit()
 
 	resp, err := client.GetFuturesCurve(ctx, WithContract("ice-brent"))
+	if skipIfRateLimited(t, err) {
+		return
+	}
 	if err != nil {
 		t.Fatalf("GetFuturesCurve(ice-brent) returned error (path regression?): %v", err)
 	}
@@ -132,6 +158,9 @@ func TestLiveGetMarketBrief(t *testing.T) {
 	liveRateLimit()
 
 	resp, err := client.GetMarketBrief(ctx, []string{"BRENT_CRUDE_USD"})
+	if skipIfRateLimited(t, err) {
+		return
+	}
 	if err != nil {
 		t.Fatalf("GetMarketBrief(BRENT_CRUDE_USD) returned error: %v", err)
 	}
@@ -156,6 +185,9 @@ func TestLiveGetSubscriptions(t *testing.T) {
 	liveRateLimit()
 
 	resp, err := client.GetSubscriptions(ctx)
+	if skipIfRateLimited(t, err) {
+		return
+	}
 	if err != nil {
 		t.Fatalf("GetSubscriptions returned error: %v", err)
 	}


### PR DESCRIPTION
## What

The live tests (`//go:build live`) hit the real production API using a single shared CI key rate-limited to ~1 req/sec. That key is shared across SDK repos, so cross-repo contention can return **HTTP 429** even when the SDK code under test is perfectly correct. The result: green code gets red-flagged by transient rate-limit failures.

This change makes live tests treat a 429 as a **SKIP**, not a failure.

## How

- Added a `skipIfRateLimited(t, err)` helper in `live_test.go` that uses `errors.As` to detect a `*RateLimitError` (HTTP 429 — confirmed in `errors.go`). On a 429 it calls `t.Skip("rate-limited (shared CI key) — skipping live assertion")` and returns `true`; otherwise returns `false` so the test falls through to its normal assertions.
- Called the helper immediately after each live API call across all five live tests (futures latest x2, futures curve, market-brief, subscriptions).

## Preserved

- Existing `t.Skip` when `OILPRICEAPI_TEST_KEY` is absent.
- The `>=1.1s` request spacing via `liveRateLimit()`.

## Gates

- `go build ./...` ✅
- `go vet ./...` and `go vet -tags live ./...` ✅
- `gofmt -l .` clean ✅
- `go test -cover ./...` ✅ **85.5%** (≥80%)

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved live test resilience to handle rate-limit errors gracefully. Tests now skip when rate-limited in CI environments instead of failing, reducing flakiness from shared API key contention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->