### PR TITLE
feat: Raw() escape hatch + surface note (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,28 @@ connection down cleanly and closes `Updates()`. Tune behaviour with
 `WithStreamAutoReconnect`, `WithStreamReconnectDelay`, `WithStreamMaxReconnectDelay`,
 and `WithStreamMaxReconnectAttempts`.
 
+### API Surface & Escape Hatch
+
+The core endpoints are first-class typed methods: spot prices (latest and
+past-period/date-range historical), futures (latest contracts and forward
+curve), and energy intelligence (oil inventories, OPEC production, well
+permits), plus forecasts, storage, rig counts, drilling, marine fuels, alerts,
+webhooks, analytics, market brief, subscriptions, and streaming.
+
+Everything else the API serves — including endpoints added after this SDK
+release — is reachable via `Raw()`, which uses the same authentication,
+retries, and typed errors as every other method:
+
+```go
+var out map[string]any
+err := client.Raw(ctx, http.MethodGet, "/v1/some/new/endpoint",
+    url.Values{"days": {"30"}}, &out)
+```
+
+Deeper typed coverage lands based on demand — if you're using `Raw()` for an
+endpoint regularly, [open an issue](https://github.com/OilpriceAPI/oilpriceapi-go/issues)
+and it becomes a candidate for a first-class method.
+
 ## Error Handling
 
 The SDK provides typed errors for common API error conditions:

--- a/raw.go
+++ b/raw.go
@@ -1,0 +1,49 @@
+package oilpriceapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// Raw performs an authenticated request against an arbitrary API path and
+// JSON-decodes the response into v.
+//
+// It is the escape hatch for endpoints the SDK does not (yet) wrap with a
+// typed method: it uses the same authentication, User-Agent, and retry/backoff
+// behaviour as every other client method, and surfaces API errors via the same
+// error types (AuthenticationError, RateLimitError, NotFoundError,
+// ServerError, APIError).
+//
+// path must start with "/" (e.g. "/v1/prices/latest"). query is optional and
+// may be nil; when set it is encoded and appended to the path. v may be nil to
+// discard the response body (useful for DELETE-style calls); otherwise it must
+// be a pointer suitable for json.Unmarshal.
+//
+// Example:
+//
+//	var out map[string]any
+//	err := client.Raw(ctx, http.MethodGet, "/v1/some/new/endpoint",
+//	    url.Values{"days": {"30"}}, &out)
+func (c *Client) Raw(ctx context.Context, method, path string, query url.Values, v any) error {
+	endpoint := path
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+
+	resp, err := c.doRequest(ctx, method, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.handleError(resp)
+	}
+
+	if v == nil || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(v)
+}

--- a/raw_test.go
+++ b/raw_test.go
@@ -1,0 +1,167 @@
+package oilpriceapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// ===================
+// RAW ESCAPE HATCH
+// ===================
+
+func TestRaw(t *testing.T) {
+	t.Run("decodes response and sends auth header", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/some/new/endpoint" {
+				t.Errorf("expected path /v1/some/new/endpoint, got %s", r.URL.Path)
+			}
+			if r.Method != "GET" {
+				t.Errorf("expected GET method, got %s", r.Method)
+			}
+			if r.Header.Get("Authorization") != "Token test-key" {
+				t.Errorf("expected auth header 'Token test-key', got '%s'", r.Header.Get("Authorization"))
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data":   map[string]any{"value": 42.5},
+			})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+
+		var out struct {
+			Status string `json:"status"`
+			Data   struct {
+				Value float64 `json:"value"`
+			} `json:"data"`
+		}
+		err := client.Raw(context.Background(), http.MethodGet, "/v1/some/new/endpoint", nil, &out)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if out.Status != "success" {
+			t.Errorf("expected status 'success', got '%s'", out.Status)
+		}
+		if out.Data.Value != 42.5 {
+			t.Errorf("expected value 42.5, got %f", out.Data.Value)
+		}
+	})
+
+	t.Run("passes query params through", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			q := r.URL.Query()
+			if q.Get("by_code") != "BRENT_CRUDE_USD" {
+				t.Errorf("expected by_code=BRENT_CRUDE_USD, got %s", q.Get("by_code"))
+			}
+			if q.Get("days") != "30" {
+				t.Errorf("expected days=30, got %s", q.Get("days"))
+			}
+			json.NewEncoder(w).Encode(map[string]string{"status": "success"})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+
+		var out map[string]any
+		err := client.Raw(context.Background(), http.MethodGet, "/v1/prices/latest", url.Values{
+			"by_code": {"BRENT_CRUDE_USD"},
+			"days":    {"30"},
+		}, &out)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("allows nil destination to discard body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "DELETE" {
+				t.Errorf("expected DELETE method, got %s", r.Method)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		err := client.Raw(context.Background(), http.MethodDelete, "/v1/webhooks/wh_001", nil, nil)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("surfaces API errors via existing error types", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error": "not found"}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(0))
+
+		var out map[string]any
+		err := client.Raw(context.Background(), http.MethodGet, "/v1/does/not/exist", nil, &out)
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !isNotFoundError(err) {
+			t.Errorf("expected NotFoundError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("surfaces authentication error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error": "Unauthorized"}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("bad-key", WithBaseURL(server.URL), WithRetries(0))
+
+		var out map[string]any
+		err := client.Raw(context.Background(), http.MethodGet, "/v1/prices/latest", nil, &out)
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !isAuthError(err) {
+			t.Errorf("expected AuthenticationError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("retries on 429 like other methods", func(t *testing.T) {
+		attempts := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			attempts++
+			if attempts < 3 {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]string{"status": "success"})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(3))
+
+		var out map[string]any
+		err := client.Raw(context.Background(), http.MethodGet, "/v1/some/endpoint", nil, &out)
+
+		if err != nil {
+			t.Fatalf("expected success after retry, got error: %v", err)
+		}
+		if attempts != 3 {
+			t.Errorf("expected 3 attempts, got %d", attempts)
+		}
+		if out["status"] != "success" {
+			t.Errorf("expected status 'success', got %v", out["status"])
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a raw-request escape hatch to the Go SDK so every OilPriceAPI endpoint is reachable, even ones without a typed wrapper yet:

```go
func (c *Client) Raw(ctx context.Context, method, path string, query url.Values, v any) error
```

- Reuses the existing `doRequest` helper — same `Token` authentication, User-Agent, and retry/backoff logic (429 + 5xx with `Retry-After` support). No duplicated retry code.
- Surfaces API errors through the existing typed errors (`AuthenticationError`, `RateLimitError`, `NotFoundError`, `ServerError`, `APIError`).
- JSON-decodes into `v`; `v == nil` discards the body (DELETE-style calls), and 204 responses skip decoding.

## README

New **API Surface & Escape Hatch** subsection at the end of the API Reference: core endpoints (spot latest/past, futures latest + curve, energy-intelligence inventories/OPEC/well-permits, etc.) are first-class typed methods; everything else goes through `Raw()` with a 3-line example. Deeper typed coverage lands based on demand.

## Test evidence

`go test ./...` → `ok github.com/OilpriceAPI/oilpriceapi-go 1.283s` (live tests excluded via the `live` build tag; they skip without `OILPRICEAPI_TEST_KEY`)
`go vet ./...` → clean

New `TestRaw` suite (repo's existing httptest style), all passing:
- decodes response and sends auth header
- passes query params through
- allows nil destination to discard body
- surfaces API errors via existing error types (404 → `NotFoundError`)
- surfaces authentication error (401 → `AuthenticationError`)
- retries on 429 like other methods (3 attempts observed)

Refs #12 — closes the surface-gap half of it (maintenance-mode direction approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a flexible API request method for calling any endpoint while preserving authentication, retries, and standard error handling.
  * Support for optional query parameters, JSON decoding into custom types, and no-content responses.
* **Documentation**
  * Expanded the README with guidance on when to use the typed SDK methods versus the new direct request option, including an example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->