### PR TITLE
fix: drop venue-typed source enums; align examples with market_reporting (#4175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to the OilPriceAPI Go SDK will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.1] - 2026-07-10
+
+### Changed
+
+- Loosen `source` typing and align examples with the API's masked source labels: the response `source` now returns `market_reporting` for non-government series (government labels like `EIA`/`opec.org` are unchanged). The `Source` struct fields remain free `string` types (no venue enum); test fixtures no longer use venue names such as `ICE`. See oilpriceapi-api#4175.

--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@ const (
 	// DefaultRetries is the default number of retries.
 	DefaultRetries = 3
 	// Version is the SDK version.
-	Version = "1.2.0"
+	Version = "1.2.1"
 )
 
 // futuresContractSlugs maps short futures contract codes to the API path slug

--- a/client_test.go
+++ b/client_test.go
@@ -505,7 +505,7 @@ func TestGetFuturesLatest(t *testing.T) {
 
 			response := FuturesResponse{
 				Commodity: "BRENT_FUTURES",
-				Source:    "ICE",
+				Source:    "market_reporting",
 				FrontMonth: &FuturesContract{
 					Code: "BZF25", ContractMonth: "2026-08", LastPrice: 78.50, Currency: "USD",
 				},
@@ -603,7 +603,7 @@ func TestGetFuturesCurve(t *testing.T) {
 
 			response := FuturesResponse{
 				Commodity: "BRENT_FUTURES",
-				Source:    "ICE",
+				Source:    "market_reporting",
 				Contracts: []FuturesContract{
 					{Code: "BZF25", ContractMonth: "2026-08", LastPrice: 78.50},
 				},


### PR DESCRIPTION
## What & why

Part of the SDK-fleet sweep for oilpriceapi-api#4175. The API is switching masked source labels to `market_reporting` (government labels like `EIA`/`opec.org` unchanged). This aligns the Go SDK.

## Typing

No enum to loosen — all `Source` struct fields in `types.go` are already `string` (`json:"source,omitempty"`). So nothing breaks when the API starts returning `market_reporting`.

## Examples/fixtures fixed

- `client_test.go`: two futures response fixtures `Source: "ICE"` → `Source: "market_reporting"` (lines 508, 606). The unrelated `Source: "aggregated"` fixture/assertion is left as-is.

Left unchanged intentionally: nothing in this SDK hard-codes venue route slugs; no README venue-as-source claims.

## Version (unpublished)

- `Version` const in `client.go` `1.2.0` → `1.2.1`; new `CHANGELOG.md` with the entry. **No git tag created / not published** to pkg.go.dev.

## Test/build

- `go build ./...`: ok
- `go test ./...`: ok (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
