### PR TITLE
fix: decode production /v1/prices/latest single-object envelope (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the OilPriceAPI Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `GetLatestPrices` now decodes the production `/v1/prices/latest` response, which returns a single price object in `data` rather than a `{"prices": [...]}` list. Previously the call succeeded with an empty `Data.Prices` slice, silently breaking the README quickstart (#18). Both envelope shapes are accepted, and a 200 response with no decodable price now returns a descriptive error instead of an empty slice.
+- `Price` gained the `Formatted`, `Type`, `Source`, and `CreatedAt` fields returned by production; `Name` is documented as absent on `/v1/prices/latest` (prefer `Code`).
+
 ## [1.2.1] - 2026-07-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -95,17 +95,7 @@ func main() {
         oilpriceapi.WithRetries(3),
     )
 
-    // Get all latest prices
-    prices, err := client.GetLatestPrices(context.Background())
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    for _, p := range prices.Data.Prices {
-        fmt.Printf("%s: $%.2f\n", p.Name, p.Price)
-    }
-
-    // Get specific commodity
+    // Get the latest price for a commodity
     brent, err := client.GetLatestPrices(context.Background(),
         oilpriceapi.WithCommodity("BRENT_CRUDE_USD"),
     )
@@ -113,7 +103,8 @@ func main() {
         log.Fatal(err)
     }
 
-    fmt.Printf("Brent: $%.2f\n", brent.Data.Prices[0].Price)
+    p := brent.Data.Prices[0]
+    fmt.Printf("%s: $%.2f %s/%s (as of %s)\n", p.Code, p.Price, p.Currency, p.Unit, p.UpdatedAt)
 }
 ```
 
@@ -141,12 +132,19 @@ prices, err := client.GetDemoPrices(ctx)
 
 ### Latest Prices
 
-```go
-// All prices
-prices, err := client.GetLatestPrices(ctx)
+`/v1/prices/latest` returns the single most recent price (for the requested
+commodity, or the most recently updated commodity when no filter is given),
+exposed as a one-element `Data.Prices` slice. Call once per code to fetch
+several commodities. If the response contains no decodable price the SDK
+returns an error rather than an empty slice.
 
-// Specific commodity
+```go
+// Latest price for a specific commodity
 prices, err := client.GetLatestPrices(ctx, oilpriceapi.WithCommodity("WTI_USD"))
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("WTI: $%.2f\n", prices.Data.Prices[0].Price)
 ```
 
 ### Historical Prices

--- a/client.go
+++ b/client.go
@@ -161,15 +161,25 @@ func (c *Client) GetDemoPrices(ctx context.Context) (*DemoPricesResponse, error)
 	return &result, nil
 }
 
-// GetLatestPrices fetches the latest commodity prices.
+// GetLatestPrices fetches the latest commodity price.
+//
+// The production /v1/prices/latest endpoint returns a single price object —
+// the most recent price for the requested commodity (or the most recently
+// updated commodity when no filter is given). The result is exposed as a
+// one-element Data.Prices slice for backwards compatibility. To fetch several
+// commodities, call GetLatestPrices once per code.
+//
+// If the response contains no decodable price, an error is returned instead
+// of an empty slice.
 //
 // Example:
 //
-//	// Get all prices
+//	// Latest price (most recently updated commodity)
 //	prices, err := client.GetLatestPrices(ctx)
 //
-//	// Get specific commodity
+//	// Latest price for a specific commodity
 //	prices, err := client.GetLatestPrices(ctx, oilpriceapi.WithCommodity("BRENT_CRUDE_USD"))
+//	fmt.Printf("Brent: $%.2f\n", prices.Data.Prices[0].Price)
 func (c *Client) GetLatestPrices(ctx context.Context, opts ...LatestPricesOption) (*PricesResponse, error) {
 	options := &LatestPricesOptions{}
 	for _, opt := range opts {
@@ -194,6 +204,14 @@ func (c *Client) GetLatestPrices(ctx context.Context, opts ...LatestPricesOption
 	var result PricesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
+	}
+
+	// Fail loudly on an empty result: a successful HTTP response that decodes
+	// to zero prices means the response envelope did not match either known
+	// shape (see PriceData.UnmarshalJSON). Silently returning an empty slice
+	// broke the README quickstart (issue #18).
+	if len(result.Data.Prices) == 0 {
+		return nil, fmt.Errorf("oilpriceapi: GET %s returned HTTP 200 but no decodable prices (unexpected response envelope; please report at https://github.com/OilpriceAPI/oilpriceapi-go/issues)", endpoint)
 	}
 
 	return &result, nil

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -194,6 +195,70 @@ func TestGetLatestPrices(t *testing.T) {
 		}
 		if len(resp.Data.Prices) != 1 {
 			t.Errorf("expected 1 price, got %d", len(resp.Data.Prices))
+		}
+	})
+
+	// Regression test for issue #18: the production /v1/prices/latest endpoint
+	// returns a SINGLE price object in "data" (not {"prices": [...]}). The SDK
+	// used to decode this as zero prices and return success, silently breaking
+	// the README quickstart. Fixture captured from production on 2026-07-13.
+	t.Run("decodes production single-object envelope (issue #18)", func(t *testing.T) {
+		const prodFixture = `{"status":"success","data":{"id":"e7fb75ef-d5da-4945-838f-aad7616e724a","code":"BRENT_CRUDE_USD","price":78.81,"created_at":"2026-07-13T13:14:30.664Z","source":"market_reporting","type":"spot_price","currency":"USD","formatted":"$78.81","unit":"barrel","updated_at":"2026-07-13T13:14:30.664Z","metadata":{"source":"market_reporting","source_description":"Aggregated from published market sources"},"changes":{"24h":{"amount":3.59,"percent":4.77,"previous_price":75.22}}}}`
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(prodFixture))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.GetLatestPrices(context.Background(), WithCommodity("BRENT_CRUDE_USD"))
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Data.Prices) != 1 {
+			t.Fatalf("expected 1 price from single-object envelope, got %d", len(resp.Data.Prices))
+		}
+		p := resp.Data.Prices[0]
+		if p.Code != "BRENT_CRUDE_USD" {
+			t.Errorf("expected code BRENT_CRUDE_USD, got %q", p.Code)
+		}
+		if p.Price != 78.81 {
+			t.Errorf("expected price 78.81, got %v", p.Price)
+		}
+		if p.Currency != "USD" || p.Unit != "barrel" {
+			t.Errorf("expected USD/barrel, got %s/%s", p.Currency, p.Unit)
+		}
+		if p.Type != "spot_price" {
+			t.Errorf("expected type spot_price, got %q", p.Type)
+		}
+		if p.Source != "market_reporting" {
+			t.Errorf("expected source market_reporting, got %q", p.Source)
+		}
+		if p.Formatted != "$78.81" {
+			t.Errorf("expected formatted $78.81, got %q", p.Formatted)
+		}
+		if p.UpdatedAt != "2026-07-13T13:14:30.664Z" {
+			t.Errorf("unexpected updated_at %q", p.UpdatedAt)
+		}
+	})
+
+	t.Run("errors loudly on empty/unknown envelope instead of silent zero prices (issue #18)", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"status":"success","data":{}}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.GetLatestPrices(context.Background())
+
+		if err == nil {
+			t.Fatalf("expected error on empty envelope, got success with %d prices", len(resp.Data.Prices))
+		}
+		if !strings.Contains(err.Error(), "no decodable prices") {
+			t.Errorf("expected descriptive envelope error, got: %v", err)
 		}
 	})
 }

--- a/live_test.go
+++ b/live_test.go
@@ -198,3 +198,31 @@ func TestLiveGetSubscriptions(t *testing.T) {
 	// a 200 with a (possibly empty) slice is the success condition.
 	t.Logf("account has %d subscription(s)", len(resp.Data.Subscriptions))
 }
+
+// TestLiveGetLatestPrices is the regression guard for issue #18: the
+// production /v1/prices/latest endpoint returns a single price object in
+// "data" (not {"prices": [...]}), which older SDK versions silently decoded
+// as zero prices. This verifies the README quickstart path end to end.
+func TestLiveGetLatestPrices(t *testing.T) {
+	client := liveClient(t)
+	ctx := context.Background()
+	liveRateLimit()
+
+	resp, err := client.GetLatestPrices(ctx, WithCommodity("BRENT_CRUDE_USD"))
+	if skipIfRateLimited(t, err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("GetLatestPrices(BRENT_CRUDE_USD) returned error: %v", err)
+	}
+	if len(resp.Data.Prices) != 1 {
+		t.Fatalf("expected exactly 1 price, got %d (envelope regression?)", len(resp.Data.Prices))
+	}
+	p := resp.Data.Prices[0]
+	if p.Code != "BRENT_CRUDE_USD" {
+		t.Errorf("expected code BRENT_CRUDE_USD, got %q", p.Code)
+	}
+	if p.Price <= 0 || p.Price > 1000 {
+		t.Errorf("Brent price %.2f is outside a sane range", p.Price)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -44,18 +44,61 @@ type DemoPricesResponse struct {
 }
 
 // Price represents a single price entry.
+//
+// Name is not returned by the production /v1/prices/latest endpoint; prefer
+// Code for display. The Formatted, Type, Source, and CreatedAt fields mirror
+// the production response and may be empty on other endpoints.
 type Price struct {
 	Code      string  `json:"code"`
-	Name      string  `json:"name"`
+	Name      string  `json:"name,omitempty"`
 	Price     float64 `json:"price"`
+	Formatted string  `json:"formatted,omitempty"`
 	Currency  string  `json:"currency"`
 	Unit      string  `json:"unit"`
+	Type      string  `json:"type,omitempty"`
+	Source    string  `json:"source,omitempty"`
+	CreatedAt string  `json:"created_at,omitempty"`
 	UpdatedAt string  `json:"updated_at"`
 }
 
 // PriceData contains the data from a prices response.
+//
+// The production /v1/prices/latest endpoint returns a single price object in
+// "data" (not a {"prices": [...]} list), so PriceData accepts both shapes:
+// a single object decodes into a one-element Prices slice. This keeps the
+// documented prices.Data.Prices[0].Price access pattern working.
 type PriceData struct {
 	Prices []Price `json:"prices"`
+}
+
+// UnmarshalJSON decodes both response envelopes used by price endpoints:
+//
+//   - {"prices": [...]} — a list of prices
+//   - {"code": "...", "price": ...} — a single price object, as returned by
+//     the production /v1/prices/latest endpoint
+func (d *PriceData) UnmarshalJSON(data []byte) error {
+	// List shape first: {"prices": [...]}.
+	var list struct {
+		Prices []Price `json:"prices"`
+	}
+	if err := json.Unmarshal(data, &list); err == nil && len(list.Prices) > 0 {
+		d.Prices = list.Prices
+		return nil
+	}
+
+	// Single-object shape: the price fields live directly on "data".
+	var single Price
+	if err := json.Unmarshal(data, &single); err != nil {
+		return err
+	}
+	if single.Code == "" && single.Price == 0 {
+		// Neither shape matched — leave Prices empty so callers can surface
+		// a loud error instead of silently returning zero prices.
+		d.Prices = nil
+		return nil
+	}
+	d.Prices = []Price{single}
+	return nil
 }
 
 // PricesResponse represents the response from /v1/prices/latest.


### PR DESCRIPTION
## Summary

Fixes #18 — `GetLatestPrices` silently returned 0 prices against production, breaking the README quickstart.

### Root cause

The production `/v1/prices/latest` endpoint returns a **single price object** in `data`:

```json
{"status":"success","data":{"code":"BRENT_CRUDE_USD","price":78.81,"currency":"USD","unit":"barrel",...}}
```

but the SDK decoded `data.prices[]` (a list envelope that this endpoint never returns). `json.Unmarshal` ignores unknown fields, so the call succeeded with an empty `Data.Prices` slice — silent-empty-success on the very first quickstart call.

### Fix

- `PriceData.UnmarshalJSON` accepts **both** envelope shapes; a single object is wrapped into a one-element `Prices` slice, so the documented `prices.Data.Prices[0].Price` access pattern keeps working.
- **Loud failure**: a 200 response that decodes to zero prices now returns a descriptive error (pointing at the repo issue tracker) instead of a silent empty slice.
- `Price` gains the `Formatted`, `Type`, `Source`, `CreatedAt` fields production actually returns; `Name` documented as absent on this endpoint (prefer `Code`).
- README quickstart / API reference updated to match real endpoint semantics (single latest price per call; call once per code).

### Test evidence

- Regression test with a fixture **captured from production 2026-07-13** (single-object envelope → 1 decoded price with all fields asserted).
- Negative test: empty/unknown envelope → descriptive error, not silent success.
- Key-gated live smoke `TestLiveGetLatestPrices` (build tag `live`).

```
$ go build ./... && go vet ./... && go test ./...
ok   github.com/OilpriceAPI/oilpriceapi-go   1.276s

$ OILPRICEAPI_TEST_KEY=*** go test -tags live -run TestLiveGetLatestPrices -v .
--- PASS: TestLiveGetLatestPrices (1.75s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
