### PR TITLE
feat: well-production client + fix stale drilling types (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace mutable product claims with links to the reviewed product-facts and
   pricing contracts; add a claims drift test.
 - Add clean consumer-module and strict production first-request release gates.
+- Add the `WellProduction()` accessor and align drilling response types with
+  the current API payload.
 
 ## [1.2.1] - 2026-07-10
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ configuration. All client methods accept `context.Context`.
 | Forecasts | `GetForecasts` |
 | Storage and rig counts | `GetStorage`, `GetRigCounts` |
 | Marine fuels and drilling | `GetMarineFuels`, `GetDrillingData` |
+| Well production | `client.WellProduction()` |
 | Alerts | `GetAlerts`, `CreateAlert`, `UpdateAlert`, `DeleteAlert` |
 | Webhooks | `ListWebhooks`, `CreateWebhook`, `UpdateWebhook`, `DeleteWebhook` |
 | Analytics | `GetAnalyticsPerformance`, `GetAnalyticsCorrelation`, `GetAnalyticsTrend`, `GetAnalyticsForecast` |
@@ -133,6 +134,16 @@ Use the [Go package reference](https://pkg.go.dev/github.com/OilpriceAPI/oilpric
 for method parameters and response types. Availability varies by dataset, plan,
 source, and account entitlement; the current source is
 [pricing](https://www.oilpriceapi.com/pricing).
+
+## Well Production
+
+```go
+summary, err := client.WellProduction().GetSummary(ctx)
+```
+
+The accessor also supports state summaries, state and well history, top
+producers, and cycle-time analysis. Check the returned coverage metadata
+before treating a state or well-level result as complete.
 
 ## Historical Prices
 

--- a/client.go
+++ b/client.go
@@ -560,7 +560,12 @@ func (c *Client) GetRigCounts(ctx context.Context) (*RigCountResponse, error) {
 	return &result, nil
 }
 
-// GetDrillingIntelligence fetches the latest drilling intelligence data.
+// GetDrillingIntelligence fetches the latest drilling intelligence snapshot
+// (rig counts, frac spread count, 30-day well permits, DUC wells).
+//
+// Endpoint: GET /v1/drilling/latest — verified live against production on
+// 2026-07-13. Requires the drilling_intelligence entitlement. For
+// well-level production data see Client.WellProduction.
 func (c *Client) GetDrillingIntelligence(ctx context.Context) (*DrillingResponse, error) {
 	resp, err := c.doRequest(ctx, "GET", "/v1/drilling/latest", nil)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -887,15 +887,9 @@ func TestGetDrillingIntelligence(t *testing.T) {
 				t.Errorf("expected auth header, got '%s'", r.Header.Get("Authorization"))
 			}
 
-			response := DrillingResponse{
-				Status: "success",
-				Data: DrillingData{
-					TotalWells: 1200,
-					ActiveRigs: 450,
-					Date:       "2024-01-10",
-				},
-			}
-			json.NewEncoder(w).Encode(response)
+			// Fixture mirrors the live production response (2026-07-13).
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"status":"success","data":{"rig_counts":{"US_RIG_COUNT":581,"CANADA_RIG_COUNT":179,"INTERNATIONAL_RIG_COUNT":1073},"frac_spread_count":200,"well_permits":{"last_30d":16423,"by_state":{"UT":15403,"TX":679}},"duc_wells_total":2465,"deltas":{"rig_counts":-3,"well_permits":15217},"last_updated":"2026-07-13T00:05:27.388Z"}}`))
 		}))
 		defer server.Close()
 
@@ -905,11 +899,26 @@ func TestGetDrillingIntelligence(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if resp.Data.TotalWells != 1200 {
-			t.Errorf("expected total_wells 1200, got %d", resp.Data.TotalWells)
+		if resp.Data.RigCounts["US_RIG_COUNT"] != 581 {
+			t.Errorf("expected US_RIG_COUNT 581, got %d", resp.Data.RigCounts["US_RIG_COUNT"])
 		}
-		if resp.Data.ActiveRigs != 450 {
-			t.Errorf("expected active_rigs 450, got %d", resp.Data.ActiveRigs)
+		if resp.Data.FracSpreadCount != 200 {
+			t.Errorf("expected frac_spread_count 200, got %d", resp.Data.FracSpreadCount)
+		}
+		if resp.Data.WellPermits.Last30d != 16423 {
+			t.Errorf("expected well_permits.last_30d 16423, got %d", resp.Data.WellPermits.Last30d)
+		}
+		if resp.Data.WellPermits.ByState["TX"] != 679 {
+			t.Errorf("expected TX permits 679, got %d", resp.Data.WellPermits.ByState["TX"])
+		}
+		if resp.Data.DUCWellsTotal != 2465 {
+			t.Errorf("expected duc_wells_total 2465, got %d", resp.Data.DUCWellsTotal)
+		}
+		if resp.Data.Deltas.RigCounts != -3 {
+			t.Errorf("expected deltas.rig_counts -3, got %d", resp.Data.Deltas.RigCounts)
+		}
+		if resp.Data.LastUpdated != "2026-07-13T00:05:27.388Z" {
+			t.Errorf("unexpected last_updated %q", resp.Data.LastUpdated)
 		}
 	})
 

--- a/live_test.go
+++ b/live_test.go
@@ -228,3 +228,57 @@ func TestLiveGetSubscriptions(t *testing.T) {
 	// a 200 with a (possibly empty) slice is the success condition.
 	t.Logf("account has %d subscription(s)", len(resp.Data.Subscriptions))
 }
+
+// TestLiveWellProductionSummary smoke-tests GET /v1/well-production against
+// production (issue #17). Requires a key with the drilling_intelligence
+// feature (Scale tier); a 403 entitlement error skips rather than fails.
+func TestLiveWellProductionSummary(t *testing.T) {
+	client := liveClient(t)
+	ctx := context.Background()
+	liveRateLimit()
+
+	resp, err := client.WellProduction().GetSummary(ctx)
+	if skipIfRateLimited(t, err) {
+		return
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == 403 {
+		t.Skip("test key lacks drilling_intelligence entitlement — skipping")
+	}
+	if err != nil {
+		t.Fatalf("GetSummary returned error: %v", err)
+	}
+	if resp.Status != "success" {
+		t.Errorf("expected status success, got %q", resp.Status)
+	}
+	if len(resp.Data.TopStates) == 0 {
+		t.Error("expected at least one top state")
+	}
+}
+
+// TestLiveDrillingIntelligence verifies /v1/drilling/latest is still live and
+// that the corrected DrillingData shape decodes real production values
+// (issue #17 asked to verify before preserving the endpoint).
+func TestLiveDrillingIntelligence(t *testing.T) {
+	client := liveClient(t)
+	ctx := context.Background()
+	liveRateLimit()
+
+	resp, err := client.GetDrillingIntelligence(ctx)
+	if skipIfRateLimited(t, err) {
+		return
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == 403 {
+		t.Skip("test key lacks drilling_intelligence entitlement — skipping")
+	}
+	if err != nil {
+		t.Fatalf("GetDrillingIntelligence returned error: %v", err)
+	}
+	if resp.Data.RigCounts["US_RIG_COUNT"] <= 0 {
+		t.Errorf("expected positive US rig count, got %d (stale-shape regression?)", resp.Data.RigCounts["US_RIG_COUNT"])
+	}
+	if resp.Data.LastUpdated == "" {
+		t.Error("expected last_updated to be set")
+	}
+}

--- a/types.go
+++ b/types.go
@@ -243,23 +243,37 @@ type RigCountResponse struct {
 	Data   RigCountData `json:"data"`
 }
 
-// DrillingRegion represents drilling data for a specific region.
-type DrillingRegion struct {
-	Region string `json:"region"`
-	Count  int    `json:"count"`
+// DrillingWellPermits summarizes recent drilling permits inside a drilling
+// intelligence snapshot.
+type DrillingWellPermits struct {
+	Last30d int            `json:"last_30d"`
+	ByState map[string]int `json:"by_state,omitempty"`
 }
 
-// DrillingData contains drilling intelligence information.
+// DrillingDeltas carries the changes since the previous snapshot.
+type DrillingDeltas struct {
+	RigCounts   int `json:"rig_counts"`
+	WellPermits int `json:"well_permits"`
+}
+
+// DrillingData contains the drilling intelligence snapshot returned by
+// /v1/drilling/latest.
+//
+// This mirrors the live production response (verified 2026-07-13): rig counts
+// keyed by region code (e.g. "US_RIG_COUNT"), frac spread count, a 30-day
+// well-permit summary, DUC well total, and deltas. The previous
+// TotalWells/ActiveRigs/RegionBreakdown fields never matched the production
+// payload and always decoded to zero values; they were removed.
 type DrillingData struct {
-	TotalWells      int              `json:"total_wells"`
-	ActiveRigs      int              `json:"active_rigs"`
-	PermitsIssued   int              `json:"permits_issued,omitempty"`
-	Completions     int              `json:"completions,omitempty"`
-	RegionBreakdown []DrillingRegion `json:"region_breakdown,omitempty"`
-	Date            string           `json:"date"`
+	RigCounts       map[string]int      `json:"rig_counts"`
+	FracSpreadCount int                 `json:"frac_spread_count"`
+	WellPermits     DrillingWellPermits `json:"well_permits"`
+	DUCWellsTotal   int                 `json:"duc_wells_total"`
+	Deltas          DrillingDeltas      `json:"deltas"`
+	LastUpdated     string              `json:"last_updated"`
 }
 
-// DrillingResponse represents the response from /v1/drilling/*.
+// DrillingResponse represents the response from /v1/drilling/latest.
 type DrillingResponse struct {
 	Status string       `json:"status"`
 	Data   DrillingData `json:"data"`

--- a/wellproduction.go
+++ b/wellproduction.go
@@ -1,0 +1,556 @@
+package oilpriceapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// WellProductionClient is an accessor for the well production
+// (/v1/well-production*) endpoints.
+//
+// It is obtained from a Client via Client.WellProduction and shares the same
+// HTTP client, authentication, and retry behaviour:
+//
+//	summary, err := client.WellProduction().GetSummary(ctx)
+//
+// Well production data requires the drilling_intelligence
+// feature). Coverage note: state-level aggregates come from the EIA API
+// (monthly); well-level data comes from state regulatory agencies and is beta
+// — it is NOT complete US well-level production.
+type WellProductionClient struct {
+	client *Client
+}
+
+// WellProduction returns the well production accessor for this client.
+func (c *Client) WellProduction() *WellProductionClient {
+	return &WellProductionClient{client: c}
+}
+
+// ===================
+// Response types
+// ===================
+
+// WellProductionRecord is a single monthly production record for a state or
+// an individual well. WaterBbl and DaysProducing are nullable server-side and
+// are therefore pointers.
+type WellProductionRecord struct {
+	Period        string   `json:"period"`
+	OilBbl        float64  `json:"oil_bbl"`
+	GasMcf        float64  `json:"gas_mcf"`
+	WaterBbl      *float64 `json:"water_bbl"`
+	Boe           float64  `json:"boe"`
+	DaysProducing *int     `json:"days_producing"`
+	Source        string   `json:"source,omitempty"`
+}
+
+// WellProductionStateSummary is a state-level production summary row.
+type WellProductionStateSummary struct {
+	State  string  `json:"state"`
+	Period string  `json:"period"`
+	OilBbl float64 `json:"oil_bbl"`
+	OilBpd float64 `json:"oil_bpd"`
+	GasMcf float64 `json:"gas_mcf"`
+	Boe    float64 `json:"boe"`
+}
+
+// WellProductionCoverage describes which states and periods have data.
+type WellProductionCoverage struct {
+	StatesWithData          []string `json:"states_with_data,omitempty"`
+	WellLevelStatesWithData []string `json:"well_level_states_with_data,omitempty"`
+	LatestPeriod            string   `json:"latest_period,omitempty"`
+	TotalRecords            int      `json:"total_records,omitempty"`
+}
+
+// WellProductionSummaryData is the data payload of the national summary
+// endpoint (GET /v1/well-production).
+type WellProductionSummaryData struct {
+	National    *WellProductionRecord        `json:"national"`
+	TopStates   []WellProductionStateSummary `json:"top_states"`
+	DataSources map[string]interface{}       `json:"data_sources,omitempty"`
+	Coverage    *WellProductionCoverage      `json:"coverage,omitempty"`
+}
+
+// WellProductionSummaryResponse is the envelope returned by
+// GET /v1/well-production.
+type WellProductionSummaryResponse struct {
+	Status string                    `json:"status"`
+	Data   WellProductionSummaryData `json:"data"`
+}
+
+// WellProductionStatesData is the data payload of the state list endpoint.
+type WellProductionStatesData struct {
+	Period string                       `json:"period"`
+	Count  int                          `json:"count"`
+	States []WellProductionStateSummary `json:"states"`
+}
+
+// WellProductionStatesResponse is the envelope returned by
+// GET /v1/well-production/states.
+type WellProductionStatesResponse struct {
+	Status string                   `json:"status"`
+	Data   WellProductionStatesData `json:"data"`
+}
+
+// WellProductionDateRange is a start/end date pair (YYYY-MM-DD).
+type WellProductionDateRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// WellProductionStateDetailData is the data payload of the state history
+// endpoint.
+type WellProductionStateDetailData struct {
+	State  string                  `json:"state"`
+	Period WellProductionDateRange `json:"period"`
+	Count  int                     `json:"count"`
+	Data   []WellProductionRecord  `json:"data"`
+}
+
+// WellProductionStateDetailResponse is the envelope returned by
+// GET /v1/well-production/states/{code}.
+type WellProductionStateDetailResponse struct {
+	Status string                        `json:"status"`
+	Data   WellProductionStateDetailData `json:"data"`
+}
+
+// WellProductionWellDetailData is the data payload of the single-well history
+// endpoint.
+type WellProductionWellDetailData struct {
+	APINumber string                 `json:"api_number"`
+	Operator  string                 `json:"operator"`
+	WellName  string                 `json:"well_name"`
+	State     string                 `json:"state"`
+	Count     int                    `json:"count"`
+	Data      []WellProductionRecord `json:"data"`
+}
+
+// WellProductionWellDetailResponse is the envelope returned by
+// GET /v1/well-production/wells/{api_number}.
+type WellProductionWellDetailResponse struct {
+	Status string                       `json:"status"`
+	Data   WellProductionWellDetailData `json:"data"`
+}
+
+// WellProducer is a single row of the top-producers ranking.
+type WellProducer struct {
+	APINumber       string  `json:"api_number"`
+	Operator        string  `json:"operator"`
+	WellName        string  `json:"well_name"`
+	TotalOilBbl     float64 `json:"total_oil_bbl"`
+	TotalGasMcf     float64 `json:"total_gas_mcf"`
+	MonthsProducing int     `json:"months_producing"`
+}
+
+// WellProductionTopProducersData is the data payload of the top-producers
+// endpoint.
+type WellProductionTopProducersData struct {
+	State     string                  `json:"state"`
+	Period    WellProductionDateRange `json:"period"`
+	Count     int                     `json:"count"`
+	Producers []WellProducer          `json:"producers"`
+}
+
+// WellProductionTopProducersResponse is the envelope returned by
+// GET /v1/well-production/top-producers.
+type WellProductionTopProducersResponse struct {
+	Status string                         `json:"status"`
+	Data   WellProductionTopProducersData `json:"data"`
+}
+
+// WellCycleTimeStats is the percentile summary used by the cycle-time
+// endpoints (days from permit to first production).
+type WellCycleTimeStats struct {
+	Count      int     `json:"count"`
+	MedianDays float64 `json:"median_days"`
+	P25Days    float64 `json:"p25_days"`
+	P75Days    float64 `json:"p75_days"`
+	P90Days    float64 `json:"p90_days"`
+	MinDays    float64 `json:"min_days"`
+	MaxDays    float64 `json:"max_days"`
+	AvgDays    float64 `json:"avg_days"`
+}
+
+// WellCycleStageStats is the per-stage breakdown (permit_to_spud,
+// spud_to_completion, completion_to_production).
+type WellCycleStageStats struct {
+	Count  int     `json:"count"`
+	Median float64 `json:"median"`
+	P25    float64 `json:"p25"`
+	P75    float64 `json:"p75"`
+	Avg    float64 `json:"avg"`
+}
+
+// WellCycleQuarterSummary is a condensed quarterly cohort row embedded in the
+// cycle-time analysis response.
+type WellCycleQuarterSummary struct {
+	WellCount  int     `json:"well_count"`
+	MedianDays float64 `json:"median_days"`
+	AvgDays    float64 `json:"avg_days"`
+}
+
+// WellCycleExtreme is one of the fastest/slowest wells listed in the
+// cycle-time analysis.
+type WellCycleExtreme struct {
+	APINumber       string `json:"api_number"`
+	Operator        string `json:"operator"`
+	TotalDays       int    `json:"total_days"`
+	PermitDate      string `json:"permit_date"`
+	FirstProduction string `json:"first_production"`
+}
+
+// WellCycleTimeData is the data payload of the cycle-time analysis endpoint.
+// Filters echoes the applied query filters and is preserved raw because its
+// keys vary with the request.
+type WellCycleTimeData struct {
+	Filters            json.RawMessage                    `json:"filters,omitempty"`
+	WellCount          int                                `json:"well_count"`
+	WellsWithCycleData int                                `json:"wells_with_cycle_data"`
+	CycleTimeStats     WellCycleTimeStats                 `json:"cycle_time_stats"`
+	StageBreakdown     map[string]WellCycleStageStats     `json:"stage_breakdown,omitempty"`
+	QuarterlyCohorts   map[string]WellCycleQuarterSummary `json:"quarterly_cohorts,omitempty"`
+	TopFastest         []WellCycleExtreme                 `json:"top_fastest,omitempty"`
+	TopSlowest         []WellCycleExtreme                 `json:"top_slowest,omitempty"`
+}
+
+// WellCycleTimeResponse is the envelope returned by
+// GET /v1/well-production/cycle-time.
+type WellCycleTimeResponse struct {
+	Status string            `json:"status"`
+	Data   WellCycleTimeData `json:"data"`
+}
+
+// WellCycleCohort is a single cohort row of the cohort-comparison endpoint.
+type WellCycleCohort struct {
+	WellCount     int                `json:"well_count"`
+	WellsWithData int                `json:"wells_with_data"`
+	Stats         WellCycleTimeStats `json:"stats"`
+}
+
+// WellCycleCohortsData is the data payload of the cohort-comparison endpoint.
+type WellCycleCohortsData struct {
+	GroupBy string                     `json:"group_by"`
+	Cohorts map[string]WellCycleCohort `json:"cohorts"`
+}
+
+// WellCycleCohortsResponse is the envelope returned by
+// GET /v1/well-production/cycle-time/cohorts.
+type WellCycleCohortsResponse struct {
+	Status string               `json:"status"`
+	Data   WellCycleCohortsData `json:"data"`
+}
+
+// ===================
+// Options
+// ===================
+
+// WellProductionOptions contains the query options shared across well
+// production endpoints. Not every option applies to every endpoint; see the
+// individual With* helpers for which endpoints honour them.
+type WellProductionOptions struct {
+	Period      string
+	StartDate   string
+	EndDate     string
+	State       string
+	Limit       int
+	Months      int
+	Operator    string
+	Formation   string
+	Lat         float64
+	Lng         float64
+	RadiusMiles float64
+	hasLocation bool
+	GroupBy     string
+}
+
+// WellProductionOption is a functional option for well production methods.
+type WellProductionOption func(*WellProductionOptions)
+
+// WithProductionPeriod selects a specific month (YYYY-MM). Used by GetStates;
+// defaults to the latest available month.
+func WithProductionPeriod(period string) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.Period = period
+	}
+}
+
+// WithProductionStartDate sets the range start (YYYY-MM-DD). Used by
+// GetStateDetail, GetCycleTime, and GetCycleTimeCohorts.
+func WithProductionStartDate(date string) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.StartDate = date
+	}
+}
+
+// WithProductionEndDate sets the range end (YYYY-MM-DD). Used by
+// GetStateDetail, GetCycleTime, and GetCycleTimeCohorts.
+func WithProductionEndDate(date string) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.EndDate = date
+	}
+}
+
+// WithProductionState filters by state code (e.g. "TX"). Used by
+// GetTopProducers (as state_code, default "TX"), GetCycleTime, and
+// GetCycleTimeCohorts (as state).
+func WithProductionState(state string) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.State = state
+	}
+}
+
+// WithProductionLimit caps the number of rows returned by GetTopProducers
+// (server clamps to 1-100, default 20).
+func WithProductionLimit(limit int) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.Limit = limit
+	}
+}
+
+// WithProductionMonths sets the trailing window in months for GetTopProducers
+// (default 12).
+func WithProductionMonths(months int) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.Months = months
+	}
+}
+
+// WithProductionOperator filters GetCycleTime by operator name.
+func WithProductionOperator(operator string) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.Operator = operator
+	}
+}
+
+// WithProductionFormation filters GetCycleTime by formation.
+func WithProductionFormation(formation string) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.Formation = formation
+	}
+}
+
+// WithProductionLocation filters GetCycleTime and GetCycleTimeCohorts to a
+// geographic radius (miles) around a lat/lng point.
+func WithProductionLocation(lat, lng, radiusMiles float64) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.Lat = lat
+		o.Lng = lng
+		o.RadiusMiles = radiusMiles
+		o.hasLocation = true
+	}
+}
+
+// WithProductionGroupBy sets the cohort grouping for GetCycleTimeCohorts
+// (default "quarter").
+func WithProductionGroupBy(groupBy string) WellProductionOption {
+	return func(o *WellProductionOptions) {
+		o.GroupBy = groupBy
+	}
+}
+
+func applyWellProductionOptions(opts []WellProductionOption) *WellProductionOptions {
+	options := &WellProductionOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	return options
+}
+
+// formatFloat renders a float query param without scientific notation.
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+// ===================
+// Methods
+// ===================
+
+// GetSummary fetches the national production overview.
+//
+// Endpoint: GET /v1/well-production. Data.National may be nil when no
+// national rollup exists for the current period, and its fields can be zero
+// while backfills are running — check Data.TopStates for state-level numbers.
+func (w *WellProductionClient) GetSummary(ctx context.Context) (*WellProductionSummaryResponse, error) {
+	var result WellProductionSummaryResponse
+	if err := w.get(ctx, "/v1/well-production", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetStates fetches the latest state-level production summary, ordered by oil
+// volume. Use WithProductionPeriod to select a specific month (YYYY-MM).
+//
+// Endpoint: GET /v1/well-production/states.
+func (w *WellProductionClient) GetStates(ctx context.Context, opts ...WellProductionOption) (*WellProductionStatesResponse, error) {
+	options := applyWellProductionOptions(opts)
+
+	query := url.Values{}
+	if options.Period != "" {
+		query.Set("period", options.Period)
+	}
+
+	var result WellProductionStatesResponse
+	if err := w.get(ctx, "/v1/well-production/states", query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetStateDetail fetches monthly production history for a state (default
+// window: the last two years). Use WithProductionStartDate and
+// WithProductionEndDate to change the range.
+//
+// Endpoint: GET /v1/well-production/states/{code}. Returns *NotFoundError
+// when the state has no production data.
+func (w *WellProductionClient) GetStateDetail(ctx context.Context, stateCode string, opts ...WellProductionOption) (*WellProductionStateDetailResponse, error) {
+	if strings.TrimSpace(stateCode) == "" {
+		return nil, fmt.Errorf("oilpriceapi: state code is required")
+	}
+	options := applyWellProductionOptions(opts)
+
+	query := url.Values{}
+	if options.StartDate != "" {
+		query.Set("start_date", options.StartDate)
+	}
+	if options.EndDate != "" {
+		query.Set("end_date", options.EndDate)
+	}
+
+	var result WellProductionStateDetailResponse
+	if err := w.get(ctx, "/v1/well-production/states/"+url.PathEscape(strings.ToUpper(strings.TrimSpace(stateCode))), query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetWellDetail fetches monthly production history for a single well by its
+// 14-digit API number.
+//
+// Endpoint: GET /v1/well-production/wells/{api_number}. The server rejects
+// non-14-digit API numbers with an INVALID_PARAMETER error and returns
+// *NotFoundError when the well has no production data.
+func (w *WellProductionClient) GetWellDetail(ctx context.Context, apiNumber string) (*WellProductionWellDetailResponse, error) {
+	if strings.TrimSpace(apiNumber) == "" {
+		return nil, fmt.Errorf("oilpriceapi: well API number is required")
+	}
+
+	var result WellProductionWellDetailResponse
+	if err := w.get(ctx, "/v1/well-production/wells/"+url.PathEscape(strings.TrimSpace(apiNumber)), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetTopProducers fetches the top producing wells for a state (default TX,
+// last 12 months, 20 rows). Use WithProductionState, WithProductionMonths,
+// and WithProductionLimit to adjust.
+//
+// Endpoint: GET /v1/well-production/top-producers.
+func (w *WellProductionClient) GetTopProducers(ctx context.Context, opts ...WellProductionOption) (*WellProductionTopProducersResponse, error) {
+	options := applyWellProductionOptions(opts)
+
+	query := url.Values{}
+	if options.State != "" {
+		query.Set("state_code", options.State)
+	}
+	if options.Limit > 0 {
+		query.Set("limit", strconv.Itoa(options.Limit))
+	}
+	if options.Months > 0 {
+		query.Set("months", strconv.Itoa(options.Months))
+	}
+
+	var result WellProductionTopProducersResponse
+	if err := w.get(ctx, "/v1/well-production/top-producers", query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetCycleTime fetches permit-to-production cycle-time analysis. Filter with
+// WithProductionState, WithProductionStartDate/EndDate, WithProductionOperator,
+// WithProductionFormation, and WithProductionLocation.
+//
+// Endpoint: GET /v1/well-production/cycle-time. Returns *NotFoundError when
+// no wells match the filters.
+func (w *WellProductionClient) GetCycleTime(ctx context.Context, opts ...WellProductionOption) (*WellCycleTimeResponse, error) {
+	options := applyWellProductionOptions(opts)
+
+	var result WellCycleTimeResponse
+	if err := w.get(ctx, "/v1/well-production/cycle-time", cycleTimeQuery(options), &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetCycleTimeCohorts compares cycle times across cohorts (default grouping:
+// quarter). Accepts the same geographic and date filters as GetCycleTime plus
+// WithProductionGroupBy.
+//
+// Endpoint: GET /v1/well-production/cycle-time/cohorts.
+func (w *WellProductionClient) GetCycleTimeCohorts(ctx context.Context, opts ...WellProductionOption) (*WellCycleCohortsResponse, error) {
+	options := applyWellProductionOptions(opts)
+
+	query := cycleTimeQuery(options)
+	if options.GroupBy != "" {
+		query.Set("group_by", options.GroupBy)
+	}
+
+	var result WellCycleCohortsResponse
+	if err := w.get(ctx, "/v1/well-production/cycle-time/cohorts", query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// cycleTimeQuery builds the filter params shared by the cycle-time endpoints.
+func cycleTimeQuery(options *WellProductionOptions) url.Values {
+	query := url.Values{}
+	if options.State != "" {
+		query.Set("state", options.State)
+	}
+	if options.StartDate != "" {
+		query.Set("start_date", options.StartDate)
+	}
+	if options.EndDate != "" {
+		query.Set("end_date", options.EndDate)
+	}
+	if options.Operator != "" {
+		query.Set("operator", options.Operator)
+	}
+	if options.Formation != "" {
+		query.Set("formation", options.Formation)
+	}
+	if options.hasLocation {
+		query.Set("lat", formatFloat(options.Lat))
+		query.Set("lng", formatFloat(options.Lng))
+		query.Set("radius_miles", formatFloat(options.RadiusMiles))
+	}
+	return query
+}
+
+// get is the shared GET-and-decode implementation for well production
+// endpoints.
+func (w *WellProductionClient) get(ctx context.Context, path string, query url.Values, out interface{}) error {
+	endpoint := path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+
+	resp, err := w.client.doRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return w.client.handleError(resp)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/wellproduction.go
+++ b/wellproduction.go
@@ -18,8 +18,8 @@ import (
 //
 //	summary, err := client.WellProduction().GetSummary(ctx)
 //
-// Well production data requires the drilling_intelligence
-// feature). Coverage note: state-level aggregates come from the EIA API
+// Well production data requires the drilling_intelligence entitlement.
+// Coverage note: state-level aggregates come from the EIA API
 // (monthly); well-level data comes from state regulatory agencies and is beta
 // — it is NOT complete US well-level production.
 type WellProductionClient struct {

--- a/wellproduction_test.go
+++ b/wellproduction_test.go
@@ -1,0 +1,375 @@
+package oilpriceapi
+
+// Tests for the well production client (/v1/well-production*). Response
+// fixtures were captured from production on 2026-07-13 (issue #17).
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// wpServer spins up a test server that asserts the request path/query and
+// returns the given body.
+func wpServer(t *testing.T, wantPath string, wantQuery map[string]string, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != wantPath {
+			t.Errorf("expected path %s, got %s", wantPath, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Token test-key" {
+			t.Errorf("expected auth header, got %q", r.Header.Get("Authorization"))
+		}
+		for k, v := range wantQuery {
+			if got := r.URL.Query().Get(k); got != v {
+				t.Errorf("expected query %s=%s, got %q", k, v, got)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		w.Write([]byte(body))
+	}))
+}
+
+func TestWellProductionGetSummary(t *testing.T) {
+	t.Run("decodes national summary envelope", func(t *testing.T) {
+		// Trimmed production fixture (2026-07-13): national rollup zeroed while
+		// backfill runs, top_states populated.
+		const fixture = `{"status":"success","data":{"national":{"period":"2026-07","oil_bbl":0,"gas_mcf":0,"water_bbl":0,"boe":0,"days_producing":null,"source":"market_reporting"},"top_states":[{"state":"TX","period":"2026-04","oil_bbl":174743000,"oil_bpd":5824767,"gas_mcf":1164406000,"boe":368810667},{"state":"NM","period":"2026-04","oil_bbl":70985000,"oil_bpd":2366167,"gas_mcf":359485000,"boe":130899167}],"data_sources":{"state_aggregates":"EIA API v2 (monthly)"},"coverage":{"states_with_data":["AK","TX"],"latest_period":"2026-07","total_records":12345}}}`
+
+		server := wpServer(t, "/v1/well-production", nil, http.StatusOK, fixture)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetSummary(context.Background())
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Status != "success" {
+			t.Errorf("expected status success, got %q", resp.Status)
+		}
+		if resp.Data.National == nil {
+			t.Fatal("expected national record, got nil")
+		}
+		if resp.Data.National.Period != "2026-07" {
+			t.Errorf("expected national period 2026-07, got %q", resp.Data.National.Period)
+		}
+		if resp.Data.National.DaysProducing != nil {
+			t.Errorf("expected nil days_producing, got %v", *resp.Data.National.DaysProducing)
+		}
+		if len(resp.Data.TopStates) != 2 {
+			t.Fatalf("expected 2 top states, got %d", len(resp.Data.TopStates))
+		}
+		tx := resp.Data.TopStates[0]
+		if tx.State != "TX" || tx.OilBbl != 174743000 || tx.OilBpd != 5824767 {
+			t.Errorf("unexpected TX row: %+v", tx)
+		}
+		if resp.Data.Coverage == nil || resp.Data.Coverage.TotalRecords != 12345 {
+			t.Errorf("unexpected coverage: %+v", resp.Data.Coverage)
+		}
+	})
+
+	t.Run("handles null national (empty successful response)", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production", nil, http.StatusOK,
+			`{"status":"success","data":{"national":null,"top_states":[]}}`)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetSummary(context.Background())
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Data.National != nil {
+			t.Errorf("expected nil national, got %+v", resp.Data.National)
+		}
+		if len(resp.Data.TopStates) != 0 {
+			t.Errorf("expected 0 top states, got %d", len(resp.Data.TopStates))
+		}
+	})
+
+	t.Run("surfaces entitlement error (Scale tier gate)", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production", nil, http.StatusForbidden,
+			`{"error":{"code":"ENTERPRISE_REQUIRED","message":"Well production data requires the Scale plan. Contact sales@oilpriceapi.com for access.","status":403}}`)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(0))
+		_, err := client.WellProduction().GetSummary(context.Background())
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected *APIError, got %T: %v", err, err)
+		}
+		if apiErr.StatusCode != http.StatusForbidden {
+			t.Errorf("expected status 403, got %d", apiErr.StatusCode)
+		}
+	})
+}
+
+func TestWellProductionGetStates(t *testing.T) {
+	const fixture = `{"status":"success","data":{"period":"2026-04","count":2,"states":[{"state":"TX","period":"2026-04","oil_bbl":174743000,"oil_bpd":5824767,"gas_mcf":1164406000,"boe":368810667},{"state":"NM","period":"2026-04","oil_bbl":70985000,"oil_bpd":2366167,"gas_mcf":359485000,"boe":130899167}]}}`
+
+	t.Run("decodes state list", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/states", nil, http.StatusOK, fixture)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetStates(context.Background())
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Data.Period != "2026-04" || resp.Data.Count != 2 || len(resp.Data.States) != 2 {
+			t.Errorf("unexpected data: %+v", resp.Data)
+		}
+	})
+
+	t.Run("sends period param", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/states", map[string]string{"period": "2026-03"}, http.StatusOK, fixture)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		_, err := client.WellProduction().GetStates(context.Background(), WithProductionPeriod("2026-03"))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("empty successful response decodes to zero states", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/states", nil, http.StatusOK,
+			`{"status":"success","data":{"period":"2026-04","count":0,"states":[]}}`)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetStates(context.Background())
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Data.Count != 0 || len(resp.Data.States) != 0 {
+			t.Errorf("expected empty states, got %+v", resp.Data)
+		}
+	})
+}
+
+func TestWellProductionGetStateDetail(t *testing.T) {
+	const fixture = `{"status":"success","data":{"state":"TX","period":{"start":"2024-07-13","end":"2026-07-13"},"count":1,"data":[{"period":"2025-06","oil_bbl":172690000,"gas_mcf":1110000000,"water_bbl":null,"boe":357690000,"days_producing":null,"source":"eia_api"}]}}`
+
+	t.Run("builds path, uppercases state, sends date range", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/states/TX",
+			map[string]string{"start_date": "2025-01-01", "end_date": "2025-12-31"},
+			http.StatusOK, fixture)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetStateDetail(context.Background(), "tx",
+			WithProductionStartDate("2025-01-01"),
+			WithProductionEndDate("2025-12-31"),
+		)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Data.State != "TX" || resp.Data.Period.Start != "2024-07-13" {
+			t.Errorf("unexpected data: %+v", resp.Data)
+		}
+		rec := resp.Data.Data[0]
+		if rec.WaterBbl != nil {
+			t.Errorf("expected nil water_bbl, got %v", *rec.WaterBbl)
+		}
+		if rec.Source != "eia_api" {
+			t.Errorf("expected source eia_api, got %q", rec.Source)
+		}
+	})
+
+	t.Run("unsupported state returns NotFoundError", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/states/ZZ", nil, http.StatusNotFound,
+			`{"error":{"code":"DATA_NOT_AVAILABLE","message":"No production data for state: ZZ","status":404}}`)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(0))
+		_, err := client.WellProduction().GetStateDetail(context.Background(), "ZZ")
+
+		var nfErr *NotFoundError
+		if !errors.As(err, &nfErr) {
+			t.Fatalf("expected *NotFoundError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("empty state code fails client-side", func(t *testing.T) {
+		client := NewClient("test-key")
+		_, err := client.WellProduction().GetStateDetail(context.Background(), " ")
+		if err == nil {
+			t.Fatal("expected error for empty state code")
+		}
+	})
+}
+
+func TestWellProductionGetWellDetail(t *testing.T) {
+	const fixture = `{"status":"success","data":{"api_number":"42329447130000","operator":"FIREBIRD ENERGY II LLC","well_name":"MBE","state":"TX","count":1,"data":[{"period":"2023-11","oil_bbl":0,"gas_mcf":0,"water_bbl":null,"boe":0,"days_producing":null,"source":"tx_rrc"}]}}`
+
+	t.Run("decodes well history", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/wells/42329447130000", nil, http.StatusOK, fixture)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetWellDetail(context.Background(), "42329447130000")
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		d := resp.Data
+		if d.APINumber != "42329447130000" || d.Operator != "FIREBIRD ENERGY II LLC" || d.WellName != "MBE" || d.State != "TX" {
+			t.Errorf("unexpected data: %+v", d)
+		}
+	})
+
+	t.Run("invalid API number returns APIError 400", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/wells/notanapi", nil, http.StatusBadRequest,
+			`{"error":{"code":"INVALID_PARAMETER","message":"API number must be 14 digits.","status":400}}`)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(0))
+		_, err := client.WellProduction().GetWellDetail(context.Background(), "notanapi")
+
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected *APIError, got %T: %v", err, err)
+		}
+		if apiErr.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected status 400, got %d", apiErr.StatusCode)
+		}
+	})
+
+	t.Run("empty API number fails client-side", func(t *testing.T) {
+		client := NewClient("test-key")
+		_, err := client.WellProduction().GetWellDetail(context.Background(), "")
+		if err == nil {
+			t.Fatal("expected error for empty API number")
+		}
+	})
+}
+
+func TestWellProductionGetTopProducers(t *testing.T) {
+	const fixture = `{"status":"success","data":{"state":"TX","period":{"start":"2025-07-01","end":"2026-07-13"},"count":1,"producers":[{"api_number":"42329447130000","operator":"FIREBIRD ENERGY II LLC","well_name":"MBE","total_oil_bbl":1004658,"total_gas_mcf":1605878,"months_producing":7}]}}`
+
+	t.Run("decodes producers and sends params", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/top-producers",
+			map[string]string{"state_code": "NM", "limit": "5", "months": "6"},
+			http.StatusOK, fixture)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetTopProducers(context.Background(),
+			WithProductionState("NM"),
+			WithProductionLimit(5),
+			WithProductionMonths(6),
+		)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		p := resp.Data.Producers[0]
+		if p.APINumber != "42329447130000" || p.TotalOilBbl != 1004658 || p.MonthsProducing != 7 {
+			t.Errorf("unexpected producer: %+v", p)
+		}
+	})
+}
+
+func TestWellProductionGetCycleTime(t *testing.T) {
+	const fixture = `{"status":"success","data":{"filters":{"state":"TX"},"well_count":10000,"wells_with_cycle_data":1900,"cycle_time_stats":{"count":1900,"median_days":400,"p25_days":396,"p75_days":457,"p90_days":516,"min_days":1,"max_days":593,"avg_days":422},"stage_breakdown":{"permit_to_spud":{"count":2,"median":149,"p25":122,"p75":149,"avg":136}},"quarterly_cohorts":{"2024-Q3":{"well_count":406,"median_days":512,"avg_days":488}},"top_fastest":[{"api_number":"42285343290000","operator":"FW EAGLE FORD I, LLC","total_days":46,"permit_date":"2025-07-17","first_production":"2025-09-01"}],"top_slowest":[{"api_number":"42289322100000","operator":"COMSTOCK OIL & GAS, LLC","total_days":132,"permit_date":"2025-05-22","first_production":"2025-10-01"}]}}`
+
+	t.Run("decodes analysis and sends filters", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/cycle-time",
+			map[string]string{
+				"state": "TX", "start_date": "2024-01-01", "end_date": "2025-12-31",
+				"operator": "ACME", "formation": "EAGLE FORD",
+				"lat": "31.9", "lng": "-102.1", "radius_miles": "50",
+			},
+			http.StatusOK, fixture)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetCycleTime(context.Background(),
+			WithProductionState("TX"),
+			WithProductionStartDate("2024-01-01"),
+			WithProductionEndDate("2025-12-31"),
+			WithProductionOperator("ACME"),
+			WithProductionFormation("EAGLE FORD"),
+			WithProductionLocation(31.9, -102.1, 50),
+		)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		d := resp.Data
+		if d.WellCount != 10000 || d.WellsWithCycleData != 1900 {
+			t.Errorf("unexpected counts: %+v", d)
+		}
+		if d.CycleTimeStats.MedianDays != 400 || d.CycleTimeStats.P90Days != 516 {
+			t.Errorf("unexpected stats: %+v", d.CycleTimeStats)
+		}
+		if d.StageBreakdown["permit_to_spud"].Median != 149 {
+			t.Errorf("unexpected stage breakdown: %+v", d.StageBreakdown)
+		}
+		if d.QuarterlyCohorts["2024-Q3"].WellCount != 406 {
+			t.Errorf("unexpected quarterly cohorts: %+v", d.QuarterlyCohorts)
+		}
+		if len(d.TopFastest) != 1 || d.TopFastest[0].TotalDays != 46 {
+			t.Errorf("unexpected top_fastest: %+v", d.TopFastest)
+		}
+	})
+
+	t.Run("no matching wells returns NotFoundError", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/cycle-time", nil, http.StatusNotFound,
+			`{"error":{"code":"DATA_NOT_AVAILABLE","message":"No wells match the requested filters","status":404}}`)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL), WithRetries(0))
+		_, err := client.WellProduction().GetCycleTime(context.Background())
+
+		var nfErr *NotFoundError
+		if !errors.As(err, &nfErr) {
+			t.Fatalf("expected *NotFoundError, got %T: %v", err, err)
+		}
+	})
+}
+
+func TestWellProductionGetCycleTimeCohorts(t *testing.T) {
+	const fixture = `{"status":"success","data":{"group_by":"quarter","cohorts":{"2024-Q3":{"well_count":406,"wells_with_data":406,"stats":{"count":406,"median_days":512,"p25_days":485,"p75_days":525,"p90_days":549,"min_days":1,"max_days":593,"avg_days":488}}}}}`
+
+	t.Run("decodes cohorts and sends group_by", func(t *testing.T) {
+		server := wpServer(t, "/v1/well-production/cycle-time/cohorts",
+			map[string]string{"group_by": "quarter", "state": "TX"},
+			http.StatusOK, fixture)
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL))
+		resp, err := client.WellProduction().GetCycleTimeCohorts(context.Background(),
+			WithProductionGroupBy("quarter"),
+			WithProductionState("TX"),
+		)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Data.GroupBy != "quarter" {
+			t.Errorf("expected group_by quarter, got %q", resp.Data.GroupBy)
+		}
+		cohort, ok := resp.Data.Cohorts["2024-Q3"]
+		if !ok {
+			t.Fatalf("expected 2024-Q3 cohort, got %+v", resp.Data.Cohorts)
+		}
+		if cohort.WellsWithData != 406 || cohort.Stats.MedianDays != 512 {
+			t.Errorf("unexpected cohort: %+v", cohort)
+		}
+	})
+}


### PR DESCRIPTION
Rebased onto current `main` after the singleton latest-price fix landed separately.\n\nAdds the well-production accessor and aligns drilling types with the current API payload. Documentation now states coverage limits and directs callers to coverage metadata.\n\nVerification: `go test ./...` passes locally after rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added well production data access, including summaries, state and well histories, top producers, and cycle-time analysis.
  * Added filtering by period, dates, state, operator, formation, location, limits, and grouping.
  * Added coverage guidance for identifying incomplete production results.

* **Improvements**
  * Updated drilling intelligence responses to reflect the current API format, including rig counts, permits, DUC wells, deltas, and update timestamps.
  * Expanded documentation and examples for well production and drilling intelligence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->