### PR TITLE
fix: align latest-price quickstart with production

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test Go SDK
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 
@@ -33,6 +34,22 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+  clean-install:
+    name: Clean consumer example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Run exact documented example against fixtures
+        env:
+          SDK_REF: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+        run: ./scripts/clean-install-smoke.sh
+
   live:
     name: Live API tests
     runs-on: ubuntu-latest
@@ -61,4 +78,4 @@ jobs:
             echo "OILPRICEAPI_TEST_KEY not set — skipping live tests (fork or unconfigured)."
             exit 0
           fi
-          go test -tags live -v ./...
+          go test -tags live -v -count=1 ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the OilPriceAPI Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-07-19
+
+### Fixed
+
+- Decode the production `/v1/prices/latest` singleton payload into one
+  `Data.Prices` entry while retaining legacy array-envelope compatibility.
+- Reject a successful latest-price response that contains no usable price
+  instead of silently returning an empty slice.
+
+### Changed
+
+- Publish an executable `OILPRICEAPI_KEY` first request with actionable missing
+  configuration, 401, 403, and 429 recovery.
+- Preserve source and production timestamp fields on `Price`.
+- Replace mutable product claims with links to the reviewed product-facts and
+  pricing contracts; add a claims drift test.
+- Add clean consumer-module and strict production first-request release gates.
+
 ## [1.2.1] - 2026-07-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,80 +1,46 @@
-# Oil Price API Go SDK
+# OilPriceAPI Go SDK
 
-> **Real-time oil, gas, LNG, carbon and fuel prices in your Go app in under 60 seconds** — idiomatic Go, full `context.Context` support, standard library only (plus `gorilla/websocket` for streaming).
+The official Go client for source-timestamped oil, gas, refined-product,
+futures, and related energy data from [OilPriceAPI](https://www.oilpriceapi.com).
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/OilpriceAPI/oilpriceapi-go.svg)](https://pkg.go.dev/github.com/OilpriceAPI/oilpriceapi-go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/OilpriceAPI/oilpriceapi-go)](https://goreportcard.com/report/github.com/OilpriceAPI/oilpriceapi-go)
 [![Tests](https://github.com/OilpriceAPI/oilpriceapi-go/actions/workflows/test.yml/badge.svg)](https://github.com/OilpriceAPI/oilpriceapi-go/actions/workflows/test.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**[Get a Free API Key](https://www.oilpriceapi.com/auth/signup?utm_source=go-sdk)** · **[Documentation](https://docs.oilpriceapi.com)** · **[API Explorer](https://api.oilpriceapi.com/swagger)** · **[Pricing](https://www.oilpriceapi.com/pricing?utm_source=go-sdk-limit)** · **[Quick start ↓](#quick-start)**
+[Get an API key](https://www.oilpriceapi.com/auth/signup?utm_source=go-sdk) |
+[Documentation](https://docs.oilpriceapi.com) |
+[API explorer](https://api.oilpriceapi.com/swagger) |
+[Pricing](https://www.oilpriceapi.com/pricing?utm_source=go-sdk-limit)
 
-The official Go SDK for [OilPriceAPI](https://www.oilpriceapi.com), the commodity price API behind fintech dashboards, fleet & logistics tools, maritime compliance platforms and energy analytics products — serving **2M+ API requests every month**.
+## Requirements
 
-## Features
+- Go 1.21 or newer
+- API base URL: `https://api.oilpriceapi.com`
+- Auth header: `Authorization: Token YOUR_API_KEY`
+- Environment variable used by the executable example: `OILPRICEAPI_KEY`
 
-- **Simple API** - Idiomatic Go with functional options pattern
-- **Context Support** - Full context.Context integration for cancellation and timeouts
-- **Typed Errors** - Custom error types for authentication, rate limits, and server errors
-- **Automatic Retries** - Configurable retry with exponential backoff
-- **Real-Time Streaming** - WebSocket price streaming with auto-reconnect (Professional+)
-- **Minimal Dependencies** - Standard library only, plus `gorilla/websocket` for streaming
-- **Comprehensive Coverage** - Latest prices, historical data (fixed periods or custom date ranges), forecasts, futures, storage, rig counts, drilling, marine fuels, price alerts, webhooks (full CRUD), analytics, market brief, agent subscriptions, Energy Intelligence (oil inventories, OPEC production, well permits), and real-time streaming
-
-## What can you get?
-
-110+ commodities across the energy complex. The ones our customers poll the most:
-
-| Code              | What it is                 | Typical use                                 |
-| ----------------- | -------------------------- | ------------------------------------------- |
-| `BRENT_CRUDE_USD` | Brent crude (global)       | dashboards, market context, deal models     |
-| `WTI_USD`         | WTI crude (US)             | trading tools, macro models                 |
-| `NATURAL_GAS_USD` | Henry Hub natural gas      | energy analytics, procurement               |
-| `DUTCH_TTF_EUR`   | TTF gas (Europe)           | European energy, LNG analytics              |
-| `JKM_LNG_USD`     | JKM LNG (Asia)             | LNG trading & shipping                      |
-| `EU_CARBON_EUR`   | EU ETS carbon allowances   | CBAM reporting, maritime compliance, ESG    |
-| `DIESEL_USD`      | Diesel (Gulf Coast)        | fleet fuel-surcharge calculators, logistics |
-| `JET_FUEL_USD`    | Jet fuel                   | aviation ops & charter pricing              |
-| `VLSFO_USD`       | Marine bunker fuel (0.5%S) | voyage costing, bunker procurement          |
-| `GOLD_USD`        | Gold                       | macro & portfolio context                   |
-
-## Installation
+## Install
 
 ```bash
 go get github.com/OilpriceAPI/oilpriceapi-go
 ```
 
-## Quick Start
+## First Request
 
-### Try Demo (No API Key Required)
+The canonical authenticated first request is:
 
-```go
-package main
-
-import (
-    "context"
-    "fmt"
-    "log"
-
-    "github.com/OilpriceAPI/oilpriceapi-go"
-)
-
-func main() {
-    // Demo endpoint - no API key needed!
-    client := oilpriceapi.NewClient("")
-
-    prices, err := client.GetDemoPrices(context.Background())
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    for _, p := range prices.Data.Prices {
-        fmt.Printf("%s: $%.2f %s/%s\n", p.Name, p.Price, p.Currency, p.Unit)
-    }
-}
+```text
+GET /v1/prices/latest?by_code=BRENT_CRUDE_USD
 ```
 
-### With API Key
+Run the repository's tested example:
+
+```bash
+export OILPRICEAPI_KEY="your-api-key"
+go run github.com/OilpriceAPI/oilpriceapi-go/example@latest
+```
+
+The same request in application code:
 
 ```go
 package main
@@ -83,601 +49,205 @@ import (
     "context"
     "fmt"
     "log"
-    "time"
+    "os"
 
-    "github.com/OilpriceAPI/oilpriceapi-go"
+    oilpriceapi "github.com/OilpriceAPI/oilpriceapi-go"
 )
 
 func main() {
-    // Create client with API key
-    client := oilpriceapi.NewClient("your-api-key",
-        oilpriceapi.WithTimeout(10*time.Second),
-        oilpriceapi.WithRetries(3),
-    )
-
-    // Get all latest prices
-    prices, err := client.GetLatestPrices(context.Background())
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    for _, p := range prices.Data.Prices {
-        fmt.Printf("%s: $%.2f\n", p.Name, p.Price)
-    }
-
-    // Get specific commodity
-    brent, err := client.GetLatestPrices(context.Background(),
+    client := oilpriceapi.NewClient(os.Getenv("OILPRICEAPI_KEY"))
+    response, err := client.GetLatestPrices(
+        context.Background(),
         oilpriceapi.WithCommodity("BRENT_CRUDE_USD"),
     )
     if err != nil {
         log.Fatal(err)
     }
 
-    fmt.Printf("Brent: $%.2f\n", brent.Data.Prices[0].Price)
+    price := response.Data.Prices[0]
+    fmt.Printf("%s %.2f %s/%s as of %s\n",
+        price.Code, price.Price, price.Currency, price.Unit, price.UpdatedAt)
 }
 ```
 
-## API Reference
+Production returns a singleton `data` object for this endpoint. The SDK
+normalizes that object to one entry in `response.Data.Prices`. It also accepts
+the legacy `data.prices[]` response for backward compatibility and rejects a
+successful response that contains no usable price.
 
-### Creating a Client
+For missing configuration and actionable 401, 403, and 429 recovery, use the
+exact executable source in [`example/main.go`](example/main.go). CI copies that
+file into a clean consumer module and runs every recovery path against fixtures.
 
-```go
-// Basic
-client := oilpriceapi.NewClient("your-api-key")
+## Demo Request
 
-// With options
-client := oilpriceapi.NewClient("your-api-key",
-    oilpriceapi.WithBaseURL("https://api.oilpriceapi.com"),
-    oilpriceapi.WithTimeout(30*time.Second),
-    oilpriceapi.WithRetries(3),
-)
-```
-
-### Demo Prices (No Auth)
+The demo endpoint does not require an API key:
 
 ```go
-prices, err := client.GetDemoPrices(ctx)
-```
-
-### Latest Prices
-
-```go
-// All prices
-prices, err := client.GetLatestPrices(ctx)
-
-// Specific commodity
-prices, err := client.GetLatestPrices(ctx, oilpriceapi.WithCommodity("WTI_USD"))
-```
-
-### Historical Prices
-
-The commodity code is the first positional argument. Use `WithPeriod` for a
-fixed lookback window (`"day"`, `"week"`, `"month"`, or `"year"`; defaults to
-`"month"`), or `WithStartDate`/`WithEndDate` for a custom range.
-
-```go
-// Fixed period (defaults to the past month)
-prices, err := client.GetHistoricalPrices(ctx, "BRENT_CRUDE_USD")
-
-// Explicit period
-prices, err := client.GetHistoricalPrices(ctx, "BRENT_CRUDE_USD",
-    oilpriceapi.WithPeriod("week"),
-)
-
-// Custom date range with daily aggregation
-prices, err := client.GetHistoricalPrices(ctx, "WTI_USD",
-    oilpriceapi.WithStartDate("2024-01-01"),
-    oilpriceapi.WithEndDate("2024-12-31"),
-    oilpriceapi.WithInterval("daily"),
-)
-
-for _, p := range prices.Data.Prices {
-    fmt.Printf("%s: $%.2f\n", p.CreatedAt, p.Price)
-}
-```
-
-### Commodities List
-
-```go
-commodities, err := client.GetCommodities(ctx)
-for _, c := range commodities.Data.Commodities {
-    fmt.Printf("%s: %s (%s)\n", c.Code, c.Name, c.Category)
-}
-```
-
-### Futures Contracts
-
-The futures contract is selected with `WithContract`, which accepts either a
-short contract **code** or an API **slug** directly (case-insensitive). It
-defaults to Brent (`ice-brent`).
-
-| Code      | Slug               | Contract                  |
-| --------- | ------------------ | ------------------------- |
-| `BZ`      | `ice-brent`        | ICE Brent Crude           |
-| `CL`      | `ice-wti`          | ICE WTI Crude             |
-| `G`, `QS` | `ice-gasoil`       | ICE Gas Oil               |
-| `NG`      | `natural-gas`      | NYMEX Natural Gas         |
-| `TTF`     | `ttf-gas`          | ICE TTF Natural Gas       |
-| `JKM`     | `lng-jkm`          | ICE JKM LNG               |
-| `EUA`     | `eua-carbon`       | ICE EUA Carbon            |
-| `UKA`     | `uk-carbon`        | ICE UKA (UK Carbon)       |
-| —         | `continuous/brent` | Continuous Brent (rolled) |
-| —         | `continuous/wti`   | Continuous WTI (rolled)   |
-
-```go
-// Get latest futures contracts (defaults to Brent / ice-brent)
-futures, err := client.GetFuturesLatest(ctx)
-// Latest settlement is on the front month:
-if futures.FrontMonth != nil {
-    fmt.Printf("Front month %s: $%.2f\n", futures.FrontMonth.ContractMonth, futures.FrontMonth.LastPrice)
-}
-for _, c := range futures.Contracts {
-    fmt.Printf("%s (%s): $%.2f\n", c.Code, c.ContractMonth, c.LastPrice)
-}
-
-// Get the WTI forward curve — by code or by slug, both work
-curve, err := client.GetFuturesCurve(ctx, oilpriceapi.WithContract("CL"))
-curve, err = client.GetFuturesCurve(ctx, oilpriceapi.WithContract("ice-wti"))
-// The curve endpoint may legitimately have no data; check curve.Error.
-if curve.Error != "" {
-    fmt.Println("No curve data:", curve.Error)
-}
-for _, c := range curve.Contracts {
-    fmt.Printf("%s: $%.2f\n", c.ContractMonth, c.LastPrice)
-}
-```
-
-### Forecasts
-
-```go
-// Monthly forecasts for all commodities
-forecasts, err := client.GetForecasts(ctx)
-for _, f := range forecasts.Data.Commodities {
-    fmt.Printf("%s 1-month: $%.2f\n", f.Commodity, f.Forecasts["1_month"].PointEstimate)
-}
-
-// Forecast for a single commodity
-wti, err := client.GetForecasts(ctx, oilpriceapi.WithForecastCommodity("WTI_USD"))
-fmt.Printf("WTI 3-month: $%.2f\n", wti.Data.Forecasts["3_month"].PointEstimate)
-
-// Backtested model accuracy
-accuracy, err := client.GetForecastsAccuracy(ctx,
-    oilpriceapi.WithLookbackMonths(24),
-)
-fmt.Printf("1-month MAPE: %.1f%%\n", accuracy.Data.Statistics.AvgMAPE1M)
-```
-
-### Storage Levels
-
-```go
-// All tracked hubs (Cushing, US SPR, regional)
-storage, err := client.GetStorage(ctx)
-for _, s := range storage.Data.Storage {
-    fmt.Printf("%s: %.1f %s\n", s.Location, s.Value, s.Units)
-}
-
-// Cushing hub detail with analytics
-cushing, err := client.GetStorageCushing(ctx)
-fmt.Printf("Cushing: %.1f %s\n", cushing.Data.Storage.Current.Value, cushing.Data.Storage.Current.Units)
-
-// Strategic Petroleum Reserve
-spr, err := client.GetStorageSPR(ctx)
-fmt.Printf("SPR: %.1f %s\n", spr.Data.Storage.Current.Value, spr.Data.Storage.Current.Units)
-```
-
-### Rig Counts
-
-```go
-rigCounts, err := client.GetRigCounts(ctx)
-fmt.Printf("Total: %d, Oil: %d, Gas: %d\n",
-    rigCounts.Data.Total, rigCounts.Data.Oil, rigCounts.Data.Gas)
-```
-
-### Marine Fuels
-
-```go
-fuels, err := client.GetMarineFuels(ctx)
-for _, p := range fuels.Data.Prices {
-    fmt.Printf("%s %s: $%.2f %s/%s\n", p.Port, p.FuelType, p.Price, p.Currency, p.Unit)
-}
-```
-
-### Drilling Intelligence
-
-```go
-drilling, err := client.GetDrillingIntelligence(ctx)
-fmt.Printf("Active rigs: %d, total wells: %d\n",
-    drilling.Data.ActiveRigs, drilling.Data.TotalWells)
-```
-
-### Price Alerts
-
-Create and manage price alerts that fire when a commodity crosses a threshold.
-
-```go
-// Create an alert
-enabled := true
-alert, err := client.CreateAlert(ctx, oilpriceapi.AlertInput{
-    Name:              "Brent $85 Alert",
-    CommodityCode:     "BRENT_CRUDE_USD",
-    ConditionOperator: "greater_than",
-    ConditionValue:    85.0,
-    WebhookURL:        "https://example.com/webhook",
-    Enabled:           &enabled,
-    CooldownMinutes:   60,
-})
-
-// List alerts
-alerts, err := client.GetAlerts(ctx)
-for _, a := range alerts {
-    fmt.Printf("%s: %s %s %.2f (enabled=%v)\n",
-        a.Name, a.CommodityCode, a.ConditionOperator, a.ConditionValue, a.Enabled)
-}
-
-// Get a single alert
-one, err := client.GetAlert(ctx, "42")
-
-// Update an alert
-updated, err := client.UpdateAlert(ctx, "42", oilpriceapi.AlertInput{ConditionValue: 90.0})
-
-// Delete an alert
-err = client.DeleteAlert(ctx, "42")
-
-// Trigger history (deprecated server-side; returns a message)
-triggers, err := client.GetAlertTriggers(ctx)
-fmt.Println(triggers.Message)
-```
-
-### Webhooks
-
-Beyond `ListWebhooks`, `CreateWebhook`, and `DeleteWebhook`, the SDK supports the
-full management lifecycle (Starter plan ($49/mo) or higher).
-
-```go
-// Get a single webhook (includes signing secret + available options)
-wh, err := client.GetWebhook(ctx, "12")
-fmt.Printf("%s -> %s (status %s)\n", wh.URL, wh.Status, wh.Status)
-
-// Update a webhook (partial — only set fields are sent)
-wh, err = client.UpdateWebhook(ctx, "12", oilpriceapi.WebhookUpdateInput{
-    Status:      "paused",
-    Description: "Temporarily disabled",
-})
-
-// Send a test delivery
-result, err := client.TestWebhook(ctx, "12")
-fmt.Printf("test: %s (code %d)\n", result.Message, result.ResponseCode)
-
-// List recent delivery events, newest first
-events, err := client.GetWebhookEvents(ctx, "12",
-    oilpriceapi.WithWebhookPage(1),
-    oilpriceapi.WithWebhookPerPage(50),
-)
-for _, e := range events.Events {
-    fmt.Printf("%s: %s (code %d)\n", e.EventType, e.Status, e.ResponseCode)
-}
-```
-
-### Analytics
-
-Advanced analytics: API usage performance, commodity correlation, trend
-analysis, and statistical forecasts (Professional+ / Scale tiers).
-
-```go
-// API usage performance for the dashboard
-perf, err := client.GetAnalyticsPerformance(ctx, oilpriceapi.WithAnalyticsRange("30d"))
-fmt.Printf("Total requests: %d (error rate %.2f%%)\n",
-    perf.Overview.TotalRequests, perf.Overview.ErrorRate)
-
-// Correlation between two commodities
-corr, err := client.GetAnalyticsCorrelation(ctx,
-    oilpriceapi.WithAnalyticsCode1("WTI_USD"),
-    oilpriceapi.WithAnalyticsCode2("BRENT_CRUDE_USD"),
-    oilpriceapi.WithAnalyticsPeriod(90),
-)
-var corrData map[string]interface{}
-_ = json.Unmarshal(corr.Raw, &corrData)
-fmt.Printf("correlation: %v\n", corrData["correlation"])
-
-// Trend / momentum analysis (type can be sma, ema, rsi, levels, or default analysis)
-trend, err := client.GetAnalyticsTrend(ctx, "WTI_USD",
-    oilpriceapi.WithAnalyticsPeriod(60))
-
-// Statistical forecast
-forecast, err := client.GetAnalyticsForecast(ctx, "WTI_USD",
-    oilpriceapi.WithAnalyticsMethod("ema"))
-fmt.Printf("forecast type=%s tier=%s\n", forecast.Type, forecast.Tier)
-```
-
-The correlation, trend, and forecast endpoints return a varying field set, so
-`AnalyticsResult` exposes the common `Type`/`Code`/`Tier` fields and preserves
-the complete payload in `Raw` (`json.RawMessage`) for fields beyond the typed
-set.
-
-### Energy Intelligence (EI)
-
-The `client.EI()` accessor exposes the `/v1/ei/*` energy-intelligence datasets.
-Each response carries the dataset-specific payload as a raw JSON `Data` field
-(decode it into your own struct) plus typed `Meta`.
-
-```go
-ei := client.EI()
-
-// EIA WPSR oil inventories (Professional+ / Scale)
-inv, err := ei.GetOilInventories(ctx)
-var invData map[string]interface{}
-_ = json.Unmarshal(inv.Data, &invData)
-fmt.Printf("source: %s, week ending: %v\n", inv.Meta.Source, invData["week_ending"])
-
-// OPEC MOMR production (Professional+ / Scale)
-opec, err := ei.GetOpecProduction(ctx, oilpriceapi.WithEIMonths(12))
-
-// State well permits (well_permits addon / enterprise)
-permits, err := ei.GetWellPermits(ctx,
-    oilpriceapi.WithEIDays(30),
-    oilpriceapi.WithEIStates("TX,OK"),
-)
-```
-
-### Market Brief
-
-`GetMarketBrief` returns a multi-commodity structured summary (latest price, 24h
-change, freshness, spreads, and a 1-month forecast where available) for the
-requested codes in a single request. Codes accept the same shorthand as the rest
-of the API (e.g. `WTI`, `BRENT`). Pass `WithNarrative(true)` to additionally
-receive a deterministic narrative `Context` and `Summary`.
-
-```go
-brief, err := client.GetMarketBrief(ctx, []string{"BRENT_CRUDE_USD", "WTI_USD"})
-for _, c := range brief.Data.Commodities {
-    fmt.Printf("%s: %.2f %s (24h %.1f%%)\n", c.Code, c.Price, c.Currency, c.Change24hPct)
-}
-for _, s := range brief.Data.Spreads {
-    fmt.Printf("%s spread: %.2f %s\n", s.Label, s.Value, s.Currency)
-}
-
-// With narrative context + summary
-brief, err = client.GetMarketBrief(ctx, []string{"WTI_USD"}, oilpriceapi.WithNarrative(true))
-fmt.Println(brief.Data.Summary)
-```
-
-### Agent Subscriptions
-
-Agent subscriptions (watches) are persistent, server-side watches over a set of
-commodity codes, re-evaluated on a fixed interval. The poll endpoint
-(`GetSubscriptionEvents`) does **not** consume your monthly request quota, so
-agents can poll it frequently.
-
-Use `ParseInterval` to convert a friendly duration (`"5m"`, `"1h"`, or a plain
-number of seconds) to `IntervalSeconds`. `Source` and `ToolName` on the input are
-sent as the `X-OPA-Source` / `X-OPA-Tool` attribution headers; `Source` defaults
-to `"sdk-go"`.
-
-```go
-// List existing subscriptions
-subs, err := client.GetSubscriptions(ctx)
-
-// Create a subscription that re-evaluates every 5 minutes
-secs, _ := oilpriceapi.ParseInterval("5m") // 300
-created, err := client.CreateSubscription(ctx, oilpriceapi.SubscriptionInput{
-    Name:            "Crude watch",
-    Codes:           []string{"BRENT_CRUDE_USD", "WTI_USD"},
-    IntervalSeconds: secs,
-    Source:          "mcp",            // optional; sent as X-OPA-Source
-    ToolName:        "claude-desktop", // optional; sent as X-OPA-Tool
-})
-id := created.Data.Subscription.ID
-
-// Poll for events from a cursor (does not count against your quota)
-var cursor int64
-for {
-    events, err := client.GetSubscriptionEvents(ctx, oilpriceapi.WithSince(cursor))
-    if err != nil {
-        break
-    }
-    for _, e := range events.Data.Events {
-        fmt.Printf("seq=%d watch=%s deltas=%v\n", e.Seq, e.WatchID, e.Deltas)
-    }
-    cursor = events.Data.Cursor
-    if !events.Data.HasMore {
-        break
-    }
-}
-
-// Delete a subscription
-err = client.DeleteSubscription(ctx, id)
-```
-
-### Real-Time Streaming (WebSocket)
-
-Stream live price updates over WebSocket using the ActionCable `EnergyPricesChannel`.
-`StreamPrices` returns a `*PriceStream`; range over `Updates()` for typed
-`Update` values and call `Err()` after the channel closes to see why the stream
-ended (`nil` on a clean `Close()` or context cancellation).
-
-> **Streaming requires a Professional+ plan ($99/mo).** The server rejects the
-> subscription on lower tiers, which surfaces as a `*StreamRejectedError` on
-> `Err()`.
-
-```go
-ctx, cancel := context.WithCancel(context.Background())
-defer cancel()
-
-stream, err := client.StreamPrices(ctx,
-    // Optional client-side filter — accepts upstream codes or streamed slugs.
-    oilpriceapi.WithStreamCommodities("BRENT_CRUDE_USD", "WTI_USD"),
-)
+client := oilpriceapi.NewClient("")
+response, err := client.GetDemoPrices(context.Background())
 if err != nil {
     log.Fatal(err)
 }
-defer stream.Close()
-
-for update := range stream.Updates() {
-    switch update.Type {
-    case "welcome":
-        // Initial snapshot delivered on subscription.
-        fmt.Printf("connected @ %s\n", update.Welcome.Data.Timestamp)
-
-    case "price_update":
-        if wti := update.Price.Prices.Oil.WTI; wti != nil && wti.OriginalPrice != nil {
-            fmt.Printf("WTI  $%.2f @ %s\n", *wti.OriginalPrice, update.Price.Timestamp)
-        }
-        if brent := update.Price.Prices.Oil.Brent; brent != nil && brent.OriginalPrice != nil {
-            fmt.Printf("Brent $%.2f @ %s\n", *brent.OriginalPrice, update.Price.Timestamp)
-        }
-
-    case "rig_count_update":
-        rc := update.RigCount.RigCount
-        fmt.Printf("%s rigs: %.0f (%s)\n", rc.Region, rc.Count, rc.Source)
-    }
-}
-
-// After the loop, check why the stream ended.
-if err := stream.Err(); err != nil {
-    log.Printf("stream ended: %v", err)
+for _, price := range response.Data.Prices {
+    fmt.Printf("%s %.2f %s/%s\n",
+        price.Code, price.Price, price.Currency, price.Unit)
 }
 ```
 
-The stream auto-reconnects with exponential backoff after transient
-disconnects. Cancelling the context (or calling `stream.Close()`) tears the
-connection down cleanly and closes `Updates()`. Tune behaviour with
-`WithStreamAutoReconnect`, `WithStreamReconnectDelay`, `WithStreamMaxReconnectDelay`,
-and `WithStreamMaxReconnectAttempts`.
+Demo availability and limits are returned by the endpoint. Authenticated
+dataset access and limits vary by plan, source, and account entitlement.
 
-### API Surface & Escape Hatch
-
-The core endpoints are first-class typed methods: spot prices (latest and
-past-period/date-range historical), futures (latest contracts and forward
-curve), and energy intelligence (oil inventories, OPEC production, well
-permits), plus forecasts, storage, rig counts, drilling, marine fuels, alerts,
-webhooks, analytics, market brief, subscriptions, and streaming.
-
-Everything else the API serves — including endpoints added after this SDK
-release — is reachable via `Raw()`, which uses the same authentication,
-retries, and typed errors as every other method:
+## Client Options
 
 ```go
-var out map[string]any
-err := client.Raw(ctx, http.MethodGet, "/v1/some/new/endpoint",
-    url.Values{"days": {"30"}}, &out)
+client := oilpriceapi.NewClient(apiKey,
+    oilpriceapi.WithTimeout(15*time.Second),
+    oilpriceapi.WithRetries(2),
+)
 ```
 
-Deeper typed coverage lands based on demand — if you're using `Raw()` for an
-endpoint regularly, [open an issue](https://github.com/OilpriceAPI/oilpriceapi-go/issues)
-and it becomes a candidate for a first-class method.
+`WithBaseURL` and `WithHTTPClient` are available for testing and custom network
+configuration. All client methods accept `context.Context`.
 
-## Error Handling
+## Core Methods
 
-The SDK provides typed errors for common API error conditions:
+| Use case | SDK method |
+| --- | --- |
+| Latest price | `GetLatestPrices` |
+| Historical prices | `GetHistoricalPrices` |
+| Commodity catalog | `GetCommodities` |
+| Futures and curves | `GetFuturesLatest`, `GetFuturesCurve` |
+| Forecasts | `GetForecasts` |
+| Storage and rig counts | `GetStorage`, `GetRigCounts` |
+| Marine fuels and drilling | `GetMarineFuels`, `GetDrillingData` |
+| Alerts | `GetAlerts`, `CreateAlert`, `UpdateAlert`, `DeleteAlert` |
+| Webhooks | `ListWebhooks`, `CreateWebhook`, `UpdateWebhook`, `DeleteWebhook` |
+| Analytics | `GetAnalyticsPerformance`, `GetAnalyticsCorrelation`, `GetAnalyticsTrend`, `GetAnalyticsForecast` |
+| Energy intelligence | `client.EI()` |
+| Market brief | `GetMarketBrief` |
+| Agent subscriptions | `GetSubscriptions`, `CreateSubscription`, `GetSubscriptionEvents`, `DeleteSubscription` |
+| WebSocket stream | `StreamPrices` |
+
+Use the [Go package reference](https://pkg.go.dev/github.com/OilpriceAPI/oilpriceapi-go)
+for method parameters and response types. Availability varies by dataset, plan,
+source, and account entitlement; the current source is
+[pricing](https://www.oilpriceapi.com/pricing).
+
+## Historical Prices
 
 ```go
-prices, err := client.GetLatestPrices(ctx)
+response, err := client.GetHistoricalPrices(ctx, "BRENT_CRUDE_USD",
+    oilpriceapi.WithPeriod("week"),
+)
+```
+
+For a custom range, use `WithStartDate`, `WithEndDate`, and `WithInterval`.
+
+## Futures
+
+```go
+response, err := client.GetFuturesLatest(ctx,
+    oilpriceapi.WithContract("ice-brent"),
+)
+if err == nil && response.FrontMonth != nil {
+    fmt.Printf("%s %.2f\n",
+        response.FrontMonth.ContractMonth,
+        response.FrontMonth.LastPrice,
+    )
+}
+```
+
+`WithContract` accepts the API slug or a supported short code such as `BZ` or
+`CL`. The SDK keeps unknown slugs forward-compatible.
+
+## Typed Errors
+
+```go
+response, err := client.GetLatestPrices(ctx,
+    oilpriceapi.WithCommodity("BRENT_CRUDE_USD"),
+)
 if err != nil {
-    switch e := err.(type) {
-    case *oilpriceapi.AuthenticationError:
-        log.Printf("Invalid API key: %s", e.Message)
-    case *oilpriceapi.RateLimitError:
-        log.Printf("Rate limited, retry after %d seconds", e.RetryAfter)
-    case *oilpriceapi.NotFoundError:
-        log.Printf("Resource not found: %s", e.Message)
-    case *oilpriceapi.ServerError:
-        log.Printf("Server error (%d): %s", e.StatusCode, e.Message)
+    var authErr *oilpriceapi.AuthenticationError
+    var rateErr *oilpriceapi.RateLimitError
+    var apiErr *oilpriceapi.APIError
+
+    switch {
+    case errors.As(err, &authErr):
+        log.Print("replace OILPRICEAPI_KEY with an active key")
+    case errors.As(err, &rateErr):
+        log.Printf("retry after %d seconds", rateErr.RetryAfter)
+    case errors.As(err, &apiErr) && (apiErr.StatusCode == 402 || apiErr.StatusCode == 403):
+        log.Print("review dataset access at https://www.oilpriceapi.com/pricing")
     default:
-        log.Printf("Unknown error: %v", err)
+        log.Printf("request failed: %v", err)
     }
 }
 ```
 
-## Context Support
+The SDK also exposes `NotFoundError`, `ServerError`, and
+`StreamRejectedError`.
 
-All methods support Go contexts for cancellation and timeouts:
+## Raw Escape Hatch
+
+Use `Raw` for a versioned API route that does not yet have a typed method:
 
 ```go
-// With timeout
-ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-defer cancel()
-
-prices, err := client.GetLatestPrices(ctx)
+var result map[string]any
+err := client.Raw(ctx, http.MethodGet, "/v1/some/versioned/route",
+    url.Values{"days": {"30"}}, &result)
 ```
 
-## Available Commodities
+## Streaming
 
-**Oil & Gas:**
+`StreamPrices` opens an ActionCable WebSocket and returns typed updates.
+Check `stream.Err()` after `Updates()` closes. Availability varies by account
+entitlement; a rejected subscription returns `StreamRejectedError` with a
+recovery link.
 
-- `BRENT_CRUDE_USD` - Brent Crude Oil
-- `WTI_USD` - WTI Crude Oil
-- `NATURAL_GAS_USD` - Natural Gas
-- `DIESEL_USD` - Diesel
-- `GASOLINE_USD` - Gasoline
-- `HEATING_OIL_USD` - Heating Oil
+Source timestamps describe the values in each response. They do not imply one
+sitewide update interval: refresh cadence varies by source, market hours,
+dataset, and plan.
 
-**Coal (8 Endpoints):**
+## Reviewed Product Facts
 
-- `CAPP_COAL_USD` - Central Appalachian Coal
-- `PRB_COAL_USD` - Powder River Basin Coal
-- `NEWCASTLE_COAL_USD` - Newcastle API6
-- `COKING_COAL_USD` - Metallurgical Coal
+The versioned, reviewed contract is
+[`product-facts.json`](https://api.oilpriceapi.com/product-facts.json). Mutable
+offer, catalog, freshness, entitlement, and data-rights claims should link to
+that contract instead of being copied into SDK documentation.
 
-[View all 100+ commodities](https://docs.oilpriceapi.com/commodities)
+Current reviewed catalog wording: a broad catalog spanning crude oil, natural
+gas, refined products, futures, marine fuels, carbon markets, metals, forex,
+and selected energy-intelligence datasets. See the
+[commodity catalog](https://www.oilpriceapi.com/commodities) for current
+availability.
 
-## Getting an API Key
+Standard plans provide API access, normalization, monitoring, and delivery;
+they do not grant ownership of source data or unrestricted raw-data
+redistribution rights. See the
+[data usage policy](https://www.oilpriceapi.com/legal/data-usage).
 
-1. Sign up at [oilpriceapi.com/signup](https://www.oilpriceapi.com/signup?utm_source=github&utm_medium=sdk_go&utm_campaign=readme)
-2. Get your API key from the dashboard
-3. Start making API calls!
+## Verify This Repository
 
-## The whole OilPriceAPI toolbox
+```bash
+go test ./...
+go test -race ./...
+go vet ./...
+./scripts/clean-install-smoke.sh
+```
 
-Same data, every stack:
+The guarded production suite requires `OILPRICEAPI_TEST_KEY`:
 
-| Tool                                                                                | Install                                    |
-| ----------------------------------------------------------------------------------- | ------------------------------------------ |
-| [Python SDK](https://github.com/OilpriceAPI/python-sdk)                             | `pip install oilpriceapi`                  |
-| [Node/TypeScript SDK](https://github.com/OilpriceAPI/oilpriceapi-node)              | `npm install oilpriceapi`                  |
-| [PHP SDK](https://github.com/OilpriceAPI/oilpriceapi-php)                           | `composer require oilpriceapi/oilpriceapi` |
-| [MCP server](https://github.com/OilpriceAPI/mcp-server) (Claude, Cursor, AI agents) | `npx -y oilpriceapi-mcp`                   |
-| [WordPress plugin](https://github.com/OilpriceAPI/oilpriceapi-wordpress-plugin)     | wordpress.org, no code                     |
+```bash
+OILPRICEAPI_TEST_KEY="your-test-key" go test -tags live -run TestLiveGetLatestPrice ./...
+```
 
 ## Support
 
-- Email: support@oilpriceapi.com
-- Issues: [GitHub Issues](https://github.com/OilpriceAPI/oilpriceapi-go/issues)
-- Docs: [Documentation](https://docs.oilpriceapi.com)
+- [Documentation](https://docs.oilpriceapi.com)
+- [API explorer](https://api.oilpriceapi.com/swagger)
+- [Status](https://status.oilpriceapi.com)
+- [GitHub issues](https://github.com/OilpriceAPI/oilpriceapi-go/issues)
+- support@oilpriceapi.com
 
-## Explore the API
-
-- 🧭 **Interactive explorer**: [api.oilpriceapi.com/swagger](https://api.oilpriceapi.com/swagger) — try every endpoint in the browser (works in demo mode, no key needed)
-- 📜 **OpenAPI spec**: [swagger.json](https://api.oilpriceapi.com/swagger.json) — import into Postman/Insomnia or generate clients; pairs with `Raw()` for endpoints ahead of the SDK
-
-## License
-
-MIT License - see [LICENSE](LICENSE) for details.
-
-## Links
-
-- [OilPriceAPI Website](https://www.oilpriceapi.com)
-- [API Documentation](https://docs.oilpriceapi.com)
-- [Pricing](https://www.oilpriceapi.com/pricing?utm_source=github&utm_medium=sdk_go&utm_campaign=pricing)
-- [Status Page](https://status.oilpriceapi.com)
-- [GitHub Repository](https://github.com/OilpriceAPI/oilpriceapi-go)
-- [Go Package](https://pkg.go.dev/github.com/OilpriceAPI/oilpriceapi-go)
-
----
-
-## Why OilPriceAPI?
-
-[OilPriceAPI](https://www.oilpriceapi.com) provides professional-grade commodity price data at **98% less cost than Bloomberg Terminal** ($24,000/year vs $45/month). Trusted by energy traders, financial analysts, and developers worldwide.
-
-### Key Benefits
-
-- **Real-time data** updated every 5 minutes
-- **Historical data** for trend analysis and backtesting
-- **99.9% uptime** with enterprise-grade reliability
-- **5-minute integration** with this Go SDK
-- **Free tier** with 100 requests to get started
-
-**[Start Free](https://www.oilpriceapi.com/signup?utm_source=github&utm_medium=sdk_go&utm_campaign=readme)** | **[View Pricing](https://www.oilpriceapi.com/pricing?utm_source=github&utm_medium=sdk_go&utm_campaign=pricing)** | **[Read Docs](https://docs.oilpriceapi.com)**
-
----
-
-Made with care by the OilPriceAPI Team
+MIT licensed. See [LICENSE](LICENSE).

--- a/analytics.go
+++ b/analytics.go
@@ -104,8 +104,8 @@ func (c *Client) GetAnalyticsTrend(ctx context.Context, commodity string, opts .
 // GetAnalyticsForecast fetches a statistical price forecast for a commodity.
 //
 // Use WithAnalyticsMethod to choose the forecast method (default "ema") and
-// WithAnalyticsPeriod to set the lookback window in days (default 90). This is a
-// Professional+ / Scale feature.
+// WithAnalyticsPeriod to set the lookback window in days (default 90). Dataset
+// access varies by plan and account entitlement.
 //
 // Example:
 //

--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@ const (
 	// DefaultRetries is the default number of retries.
 	DefaultRetries = 3
 	// Version is the SDK version.
-	Version = "1.2.1"
+	Version = "1.4.0"
 )
 
 // futuresContractSlugs maps short futures contract codes to the API path slug
@@ -165,7 +165,7 @@ func (c *Client) GetDemoPrices(ctx context.Context) (*DemoPricesResponse, error)
 //
 // Example:
 //
-//	// Get all prices
+//	// Get the default latest price
 //	prices, err := client.GetLatestPrices(ctx)
 //
 //	// Get specific commodity
@@ -178,7 +178,7 @@ func (c *Client) GetLatestPrices(ctx context.Context, opts ...LatestPricesOption
 
 	endpoint := "/v1/prices/latest"
 	if options.Commodity != "" {
-		endpoint += "?by_code=" + options.Commodity
+		endpoint += "?by_code=" + url.QueryEscape(options.Commodity)
 	}
 
 	resp, err := c.doRequest(ctx, "GET", endpoint, nil)
@@ -313,7 +313,7 @@ func (c *Client) GetHistoricalPrices(ctx context.Context, commodity string, opts
 //
 // Example:
 //
-//	// All commodities
+//	// Default forecast response
 //	forecasts, err := client.GetForecasts(ctx)
 //	for _, f := range forecasts.Data.Commodities {
 //	    fmt.Printf("%s 1m: $%.2f\n", f.Commodity, f.Forecasts["1_month"].PointEstimate)

--- a/client_test.go
+++ b/client_test.go
@@ -196,6 +196,54 @@ func TestGetLatestPrices(t *testing.T) {
 			t.Errorf("expected 1 price, got %d", len(resp.Data.Prices))
 		}
 	})
+
+	t.Run("decodes the production singleton payload", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"status":"success",
+				"data":{
+					"code":"BRENT_CRUDE_USD",
+					"name":"Brent Crude Oil",
+					"price":71.80,
+					"currency":"USD",
+					"unit":"barrel",
+					"updated_at":"2026-07-19T12:00:00Z",
+					"source":"market_reporting"
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-api-key", WithBaseURL(server.URL))
+		resp, err := client.GetLatestPrices(context.Background(), WithCommodity("BRENT_CRUDE_USD"))
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Data.Prices) != 1 {
+			t.Fatalf("expected one production price, got %d", len(resp.Data.Prices))
+		}
+		price := resp.Data.Prices[0]
+		if price.Code != "BRENT_CRUDE_USD" || price.Price != 71.80 || price.UpdatedAt != "2026-07-19T12:00:00Z" {
+			t.Fatalf("unexpected production price: %+v", price)
+		}
+	})
+
+	t.Run("rejects a success payload without a price", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success","data":{}}`))
+		}))
+		defer server.Close()
+
+		client := NewClient("test-api-key", WithBaseURL(server.URL))
+		resp, err := client.GetLatestPrices(context.Background(), WithCommodity("BRENT_CRUDE_USD"))
+
+		if err == nil {
+			t.Fatalf("expected malformed success payload to fail, got %+v", resp)
+		}
+	})
 }
 
 // ===================

--- a/ei.go
+++ b/ei.go
@@ -25,7 +25,8 @@ func (c *Client) EI() *EIClient {
 
 // GetOilInventories fetches the latest EIA WPSR oil-inventory report.
 //
-// Endpoint: GET /v1/ei/oil_inventories/latest. Requires Professional+ / Scale tier.
+// Endpoint: GET /v1/ei/oil_inventories/latest. Dataset access varies by plan
+// and account entitlement.
 //
 // The Data field holds the raw report payload (its shape mirrors the API's
 // published report JSON); decode it into your own struct if you need typed
@@ -40,16 +41,17 @@ func (e *EIClient) GetOilInventories(ctx context.Context, opts ...EIOption) (*EI
 
 // GetOpecProduction fetches the latest OPEC MOMR production report.
 //
-// Endpoint: GET /v1/ei/opec_productions/latest. Requires Professional+ / Scale tier.
+// Endpoint: GET /v1/ei/opec_productions/latest. Dataset access varies by plan
+// and account entitlement.
 func (e *EIClient) GetOpecProduction(ctx context.Context, opts ...EIOption) (*EIResponse, error) {
 	return e.get(ctx, "/v1/ei/opec_productions/latest", opts)
 }
 
 // GetWellPermits fetches the most recent drilling permits across all states.
 //
-// Endpoint: GET /v1/ei/well-permits/latest. Requires the well_permits addon or
-// an enterprise tier. Use WithEIDays to widen the trailing window (1-90, default
-// 7) and WithEIStates to filter by state code(s).
+// Endpoint: GET /v1/ei/well-permits/latest. Dataset access varies by plan and
+// account entitlement. Use WithEIDays to widen the trailing window (1-90,
+// default 7) and WithEIStates to filter by state code(s).
 func (e *EIClient) GetWellPermits(ctx context.Context, opts ...EIOption) (*EIResponse, error) {
 	return e.get(ctx, "/v1/ei/well-permits/latest", opts)
 }

--- a/errors.go
+++ b/errors.go
@@ -51,16 +51,14 @@ func (e *APIError) Error() string {
 }
 
 // StreamRejectedError is returned when the server rejects the WebSocket
-// subscription. Streaming requires a Professional+ plan ($99/mo) and
-// a valid API key; the server rejects the EnergyPricesChannel subscription
-// otherwise.
+// subscription. Dataset access varies by plan and account entitlement.
 type StreamRejectedError struct {
 	Message string
 }
 
 func (e *StreamRejectedError) Error() string {
 	if e.Message == "" {
-		return "stream subscription rejected: streaming requires a Professional+ plan ($99/mo) and a valid API key"
+		return "stream subscription rejected: verify the API key and account entitlement at https://www.oilpriceapi.com/pricing"
 	}
 	return fmt.Sprintf("stream subscription rejected: %s", e.Message)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -1,183 +1,69 @@
-// Example usage of the Oil Price API Go SDK
+// Command example runs the canonical OilPriceAPI authenticated first request.
 package main
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
 	oilpriceapi "github.com/OilpriceAPI/oilpriceapi-go"
 )
 
+const pricingURL = "https://www.oilpriceapi.com/pricing"
+
 func main() {
-	// Try demo endpoint first (no API key needed)
-	fmt.Println("=== Demo Mode (No API Key) ===")
-	demoClient := oilpriceapi.NewClient("")
-
-	demoPrices, err := demoClient.GetDemoPrices(context.Background())
-	if err != nil {
-		log.Printf("Demo error: %v\n", err)
-	} else {
-		fmt.Printf("Demo mode: %v\n", demoPrices.Data.Meta.DemoMode)
-		fmt.Printf("Rate limit: %s\n", demoPrices.Data.Meta.RateLimit)
-		fmt.Println("\nDemo Prices:")
-		for _, p := range demoPrices.Data.Prices {
-			fmt.Printf("  %s: $%.2f %s/%s\n", p.Name, p.Price, p.Currency, p.Unit)
-		}
-	}
-
-	// If API key is provided, show authenticated examples
 	apiKey := os.Getenv("OILPRICEAPI_KEY")
 	if apiKey == "" {
-		fmt.Println("\n=== Set OILPRICEAPI_KEY to see authenticated examples ===")
-		return
+		fmt.Fprintln(os.Stderr, "OILPRICEAPI_KEY is required; create a key at https://www.oilpriceapi.com/auth/signup")
+		os.Exit(2)
 	}
 
-	fmt.Println("\n=== Authenticated Mode ===")
-	client := oilpriceapi.NewClient(apiKey)
+	options := []oilpriceapi.ClientOption{
+		oilpriceapi.WithTimeout(15 * time.Second),
+		oilpriceapi.WithRetries(0),
+	}
+	if baseURL := os.Getenv("OILPRICEAPI_BASE_URL"); baseURL != "" {
+		options = append(options, oilpriceapi.WithBaseURL(baseURL))
+	}
 
-	// Get all latest prices
-	prices, err := client.GetLatestPrices(context.Background())
+	client := oilpriceapi.NewClient(apiKey, options...)
+	prices, err := client.GetLatestPrices(
+		context.Background(),
+		oilpriceapi.WithCommodity("BRENT_CRUDE_USD"),
+	)
 	if err != nil {
-		log.Fatalf("Error getting prices: %v", err)
+		exitForError(err)
 	}
 
-	fmt.Println("\nLatest Prices:")
-	for _, p := range prices.Data.Prices {
-		fmt.Printf("  %s: $%.2f %s/%s (updated: %s)\n",
-			p.Name, p.Price, p.Currency, p.Unit, p.UpdatedAt)
+	price := prices.Data.Prices[0]
+	observedAt := price.UpdatedAt
+	if observedAt == "" {
+		observedAt = price.CreatedAt
 	}
-
-	// Get specific commodity
-	brent, err := client.GetLatestPrices(context.Background(),
-		oilpriceapi.WithCommodity("BRENT_CRUDE_USD"))
-	if err != nil {
-		log.Fatalf("Error getting Brent: %v", err)
-	}
-
-	fmt.Printf("\nBrent Crude: $%.2f\n", brent.Data.Prices[0].Price)
-
-	// Get commodities list
-	commodities, err := client.GetCommodities(context.Background())
-	if err != nil {
-		log.Fatalf("Error getting commodities: %v", err)
-	}
-
-	fmt.Printf("\nAvailable Commodities: %d\n", len(commodities.Data.Commodities))
-
-	// Date-range historical prices with daily aggregation
-	history, err := client.GetHistoricalPrices(context.Background(), "WTI_USD",
-		oilpriceapi.WithStartDate("2024-01-01"),
-		oilpriceapi.WithEndDate("2024-03-31"),
-		oilpriceapi.WithInterval("daily"))
-	if err != nil {
-		log.Printf("Error getting historical range: %v\n", err)
-	} else {
-		fmt.Printf("\nWTI history points (Q1 2024): %d\n", len(history.Data.Prices))
-	}
-
-	// Monthly forecasts
-	forecasts, err := client.GetForecasts(context.Background())
-	if err != nil {
-		log.Printf("Error getting forecasts: %v\n", err)
-	} else {
-		fmt.Printf("\nForecasts for %s:\n", forecasts.Data.Period)
-		for _, f := range forecasts.Data.Commodities {
-			fmt.Printf("  %s 1-month: $%.2f\n", f.Commodity, f.Forecasts["1_month"].PointEstimate)
-		}
-	}
-
-	// Storage levels
-	storage, err := client.GetStorage(context.Background())
-	if err != nil {
-		log.Printf("Error getting storage: %v\n", err)
-	} else {
-		fmt.Println("\nStorage Levels:")
-		for _, s := range storage.Data.Storage {
-			fmt.Printf("  %s: %.1f %s\n", s.Location, s.Value, s.Units)
-		}
-	}
-
-	// Price alerts
-	alerts, err := client.GetAlerts(context.Background())
-	if err != nil {
-		log.Printf("Error getting alerts: %v\n", err)
-	} else {
-		fmt.Printf("\nPrice Alerts: %d configured\n", len(alerts))
-		for _, a := range alerts {
-			fmt.Printf("  %s: %s %s %.2f\n", a.Name, a.CommodityCode, a.ConditionOperator, a.ConditionValue)
-		}
-	}
-
-	// Analytics: API usage performance
-	perf, err := client.GetAnalyticsPerformance(context.Background(),
-		oilpriceapi.WithAnalyticsRange("30d"))
-	if err != nil {
-		log.Printf("Error getting analytics performance: %v\n", err)
-	} else {
-		fmt.Printf("\nAnalytics (30d): %d requests, %.2f%% error rate\n",
-			perf.Overview.TotalRequests, perf.Overview.ErrorRate)
-	}
-
-	// Energy Intelligence: OPEC production
-	opec, err := client.EI().GetOpecProduction(context.Background())
-	if err != nil {
-		log.Printf("Error getting OPEC production: %v\n", err)
-	} else {
-		fmt.Printf("\nEI OPEC production source: %s\n", opec.Meta.Source)
-	}
-
-	// Real-time streaming (Professional+ plan — $99/mo).
-	// Run for ~15s as a demo, then stop. On lower-tier keys the subscription is
-	// rejected and surfaces as a *StreamRejectedError on stream.Err().
-	streamExample(client)
+	fmt.Printf("%s %.2f %s/%s as of %s (source: %s)\n",
+		price.Code, price.Price, price.Currency, price.Unit, observedAt, price.Source)
 }
 
-// streamExample demonstrates the WebSocket price stream. It runs for a short
-// window then closes cleanly via context cancellation.
-//
-// Streaming requires a Professional+ plan ($99/mo); without it the server
-// rejects the subscription and stream.Err() returns a *oilpriceapi.StreamRejectedError.
-func streamExample(client *oilpriceapi.Client) {
-	fmt.Println("\n=== Real-Time Streaming (Professional+ / $99-mo) ===")
+func exitForError(err error) {
+	var authErr *oilpriceapi.AuthenticationError
+	var rateErr *oilpriceapi.RateLimitError
+	var apiErr *oilpriceapi.APIError
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	stream, err := client.StreamPrices(ctx,
-		oilpriceapi.WithStreamCommodities("BRENT_CRUDE_USD", "WTI_USD"))
-	if err != nil {
-		log.Printf("Error opening stream: %v\n", err)
-		return
-	}
-	defer stream.Close()
-
-	for update := range stream.Updates() {
-		switch update.Type {
-		case "welcome":
-			fmt.Printf("  connected (snapshot @ %s)\n", update.Welcome.Data.Timestamp)
-		case "price_update":
-			if wti := update.Price.Prices.Oil.WTI; wti != nil && wti.OriginalPrice != nil {
-				fmt.Printf("  WTI   $%.2f @ %s\n", *wti.OriginalPrice, update.Price.Timestamp)
-			}
-			if brent := update.Price.Prices.Oil.Brent; brent != nil && brent.OriginalPrice != nil {
-				fmt.Printf("  Brent $%.2f @ %s\n", *brent.OriginalPrice, update.Price.Timestamp)
-			}
-		case "rig_count_update":
-			rc := update.RigCount.RigCount
-			fmt.Printf("  %s rigs: %.0f (%s)\n", rc.Region, rc.Count, rc.Source)
-		}
-	}
-
-	if err := stream.Err(); err != nil {
-		var rejected *oilpriceapi.StreamRejectedError
-		if errors.As(err, &rejected) {
-			fmt.Printf("  streaming unavailable: %v\n", err)
+	switch {
+	case errors.As(err, &authErr):
+		fmt.Fprintln(os.Stderr, "authentication failed; replace OILPRICEAPI_KEY with an active key")
+	case errors.As(err, &rateErr):
+		if rateErr.RetryAfter > 0 {
+			fmt.Fprintf(os.Stderr, "request limit reached; retry after %d seconds or review %s\n", rateErr.RetryAfter, pricingURL)
 		} else {
-			log.Printf("  stream ended: %v\n", err)
+			fmt.Fprintf(os.Stderr, "request limit reached; retry later or review %s\n", pricingURL)
 		}
+	case errors.As(err, &apiErr) && (apiErr.StatusCode == 402 || apiErr.StatusCode == 403):
+		fmt.Fprintf(os.Stderr, "this account cannot access the requested dataset; review %s\n", pricingURL)
+	default:
+		fmt.Fprintf(os.Stderr, "latest-price request failed: %v\n", err)
 	}
+	os.Exit(1)
 }

--- a/live_test.go
+++ b/live_test.go
@@ -37,6 +37,36 @@ func liveRateLimit() {
 	time.Sleep(1100 * time.Millisecond)
 }
 
+// TestLiveGetLatestPrice is the customer-critical first-request regression
+// guard. It must decode production's singleton data object into one SDK price;
+// a 200 response with an empty slice is a failure.
+func TestLiveGetLatestPrice(t *testing.T) {
+	client := liveClient(t)
+	resp, err := client.GetLatestPrices(
+		context.Background(),
+		WithCommodity("BRENT_CRUDE_USD"),
+	)
+	if err != nil {
+		t.Fatalf("canonical latest-price request failed: %v", err)
+	}
+	if resp == nil || resp.Status != "success" {
+		t.Fatalf("expected success response, got %+v", resp)
+	}
+	if len(resp.Data.Prices) != 1 {
+		t.Fatalf("expected one normalized production price, got %d", len(resp.Data.Prices))
+	}
+	price := resp.Data.Prices[0]
+	if price.Code != "BRENT_CRUDE_USD" {
+		t.Fatalf("expected BRENT_CRUDE_USD, got %q", price.Code)
+	}
+	if price.Price <= 0 || price.Price > 1000 {
+		t.Fatalf("Brent price %.2f is outside a sane range", price.Price)
+	}
+	if price.Source == "" || (price.UpdatedAt == "" && price.CreatedAt == "") {
+		t.Fatalf("price is missing source or observation timestamp: %+v", price)
+	}
+}
+
 // skipIfRateLimited turns an HTTP 429 (*RateLimitError) from a live API call
 // into a t.Skip instead of a failure. The CI key is shared at ~1 req/sec across
 // repos, so cross-repo contention can return 429 even when the SDK code is

--- a/product_claims_test.go
+++ b/product_claims_test.go
@@ -1,0 +1,79 @@
+package oilpriceapi
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestPublicSurfaceClaimDrift(t *testing.T) {
+	publicFiles := []string{
+		"README.md",
+		"analytics.go",
+		"client.go",
+		"ei.go",
+		"errors.go",
+		"stream.go",
+		"subscriptions.go",
+		"types.go",
+		"example/main.go",
+	}
+	forbidden := map[string]*regexp.Regexp{
+		"fixed catalog total":   regexp.MustCompile(`(?i)\b\d+\+\s+(commodit|endpoint|api)`),
+		"fixed update cadence":  regexp.MustCompile(`(?i)(updated|refresh(ed)?)\s+every\s+\d+|every\s+\d+\s+minutes`),
+		"unreviewed plan name":  regexp.MustCompile(`(?i)professional\+|starter plan|scale tier`),
+		"unreviewed plan price": regexp.MustCompile(`(?i)\$\d+(\.\d+)?\s*(/|per\s+)(mo(nth)?|year)`),
+		"uptime or SLA":         regexp.MustCompile(`(?i)\b\d+(\.\d+)?%\s+uptime|\bSLA\b`),
+		"price comparison":      regexp.MustCompile(`(?i)bloomberg|\d+(\.\d+)?%\s+less\s+cost`),
+		"quota promise":         regexp.MustCompile(`(?i)does\s+not\s+consume.{0,40}quota|\bunlimited\b`),
+		"universal catalog":     regexp.MustCompile(`(?i)\ball\s+(latest\s+)?prices\b|\ball\s+commodit`),
+		"real-time claim":       regexp.MustCompile(`(?i)\breal[- ]time\b`),
+		"free-tier claim":       regexp.MustCompile(`(?i)\bfree\s+tier\b`),
+	}
+
+	for _, path := range publicFiles {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for label, pattern := range forbidden {
+			if match := pattern.Find(content); match != nil {
+				t.Errorf("%s contains %s %q; link to the reviewed product contract instead", path, label, match)
+			}
+		}
+	}
+}
+
+func TestCanonicalDeveloperContractIsDiscoverable(t *testing.T) {
+	for _, path := range []string{"README.md", "example/main.go"} {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		text := string(content)
+		for _, required := range []string{
+			"OILPRICEAPI_KEY",
+			"BRENT_CRUDE_USD",
+			"https://www.oilpriceapi.com/pricing",
+		} {
+			if !strings.Contains(text, required) {
+				t.Errorf("%s does not expose canonical developer fact %q", path, required)
+			}
+		}
+	}
+
+	readme, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"https://api.oilpriceapi.com",
+		"/v1/prices/latest?by_code=BRENT_CRUDE_USD",
+		"https://api.oilpriceapi.com/product-facts.json",
+	} {
+		if !strings.Contains(string(readme), required) {
+			t.Errorf("README.md does not expose canonical developer fact %q", required)
+		}
+	}
+}

--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+server_pid=""
+
+cleanup() {
+  if [[ -n "$server_pid" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+go run "$root_dir/scripts/fixture-server" -url-file "$tmp_dir/fixture-url" >"$tmp_dir/server.log" 2>&1 &
+server_pid=$!
+for _ in {1..50}; do
+  [[ -s "$tmp_dir/fixture-url" ]] && break
+  sleep 0.1
+done
+[[ -s "$tmp_dir/fixture-url" ]] || { echo "fixture server did not start" >&2; exit 1; }
+base_url="$(<"$tmp_dir/fixture-url")"
+
+mkdir "$tmp_dir/consumer"
+cp "$root_dir/example/main.go" "$tmp_dir/consumer/main.go"
+pushd "$tmp_dir/consumer" >/dev/null
+go mod init example-smoke >/dev/null
+if [[ -n "${SDK_REF:-}" ]]; then
+  go get "github.com/OilpriceAPI/oilpriceapi-go@${SDK_REF}" >/dev/null
+else
+  go mod edit -replace "github.com/OilpriceAPI/oilpriceapi-go=$root_dir"
+  go get github.com/OilpriceAPI/oilpriceapi-go >/dev/null
+fi
+
+OILPRICEAPI_BASE_URL="$base_url" OILPRICEAPI_KEY="valid-smoke-key" go run . >"$tmp_dir/success.out" 2>&1
+grep -q '^BRENT_CRUDE_USD 71.80 USD/barrel as of 2026-07-19T12:00:00Z (source: market_reporting)$' "$tmp_dir/success.out"
+
+set +e
+env -u OILPRICEAPI_KEY OILPRICEAPI_BASE_URL="$base_url" go run . >"$tmp_dir/missing.out" 2>&1
+missing_status=$?
+OILPRICEAPI_BASE_URL="$base_url" OILPRICEAPI_KEY="invalid-smoke-key" go run . >"$tmp_dir/auth.out" 2>&1
+auth_status=$?
+OILPRICEAPI_BASE_URL="$base_url" OILPRICEAPI_KEY="locked-smoke-key" go run . >"$tmp_dir/locked.out" 2>&1
+locked_status=$?
+OILPRICEAPI_BASE_URL="$base_url" OILPRICEAPI_KEY="limited-smoke-key" go run . >"$tmp_dir/limited.out" 2>&1
+limited_status=$?
+set -e
+
+[[ "$missing_status" -ne 0 && "$auth_status" -ne 0 && "$locked_status" -ne 0 && "$limited_status" -ne 0 ]]
+grep -q 'OILPRICEAPI_KEY is required' "$tmp_dir/missing.out"
+grep -q 'authentication failed; replace OILPRICEAPI_KEY' "$tmp_dir/auth.out"
+grep -q 'cannot access the requested dataset' "$tmp_dir/locked.out"
+grep -q 'retry after 3 seconds' "$tmp_dir/limited.out"
+
+if grep -R -E 'valid-smoke-key|invalid-smoke-key|locked-smoke-key|limited-smoke-key' "$tmp_dir"/*.out; then
+  echo "example output exposed a credential" >&2
+  exit 1
+fi
+popd >/dev/null
+
+echo "clean-install example smoke passed (success, missing config, 401, 403, 429)"

--- a/scripts/fixture-server/main.go
+++ b/scripts/fixture-server/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+)
+
+func main() {
+	urlFile := flag.String("url-file", "", "path used to publish the fixture URL")
+	flag.Parse()
+	if *urlFile == "" {
+		fmt.Fprintln(os.Stderr, "-url-file is required")
+		os.Exit(2)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(*urlFile, []byte("http://"+listener.Addr().String()), 0o600); err != nil {
+		panic(err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/prices/latest" || r.URL.Query().Get("by_code") != "BRENT_CRUDE_USD" {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "fixture route not found"})
+			return
+		}
+
+		switch r.Header.Get("Authorization") {
+		case "Token valid-smoke-key":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"code":"BRENT_CRUDE_USD","price":71.80,"currency":"USD","unit":"barrel","source":"market_reporting","created_at":"2026-07-19T12:00:00Z","updated_at":"2026-07-19T12:00:00Z"}}`))
+		case "Token invalid-smoke-key":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid API key"}`))
+		case "Token locked-smoke-key":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"dataset not enabled"}`))
+		case "Token limited-smoke-key":
+			w.Header().Set("Retry-After", "3")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"request limit reached"}`))
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"missing API key"}`))
+		}
+	})
+
+	if err := http.Serve(listener, handler); err != nil {
+		panic(err)
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -172,7 +172,7 @@ func defaultDialer(ctx context.Context, urlStr string, header http.Header) (wsCo
 	c, resp, err := dialer.DialContext(ctx, urlStr, header)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
-			return nil, &AuthenticationError{Message: "websocket handshake rejected (401): streaming requires a valid Professional+ API key"}
+			return nil, &AuthenticationError{Message: "websocket handshake rejected (401): verify the API key and account entitlement"}
 		}
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func defaultDialer(ctx context.Context, urlStr string, header http.Header) (wsCo
 	return &gorillaConn{c: c}, nil
 }
 
-// PriceStream is an active real-time price subscription. Consume typed updates
+// PriceStream is an active WebSocket price subscription. Consume typed updates
 // from Updates(); after the channel is closed, inspect Err() for the
 // terminating error (nil on a clean Close or context cancellation). Call
 // Close() to tear the stream down. PriceStream is safe for concurrent use.
@@ -221,12 +221,12 @@ func cableURL(baseURL string) string {
 	return u + "/cable"
 }
 
-// StreamPrices opens a real-time price stream over the EnergyPricesChannel.
+// StreamPrices opens a price stream over the EnergyPricesChannel.
 //
-// Streaming requires a Professional+ plan ($99/mo); the server
-// rejects the subscription otherwise, which surfaces as a *StreamRejectedError
-// on Err(). The supplied context controls the lifetime of the stream:
-// cancelling it (or calling Close) tears the connection down cleanly.
+// Availability varies by plan and account entitlement. A rejected subscription
+// surfaces as a *StreamRejectedError on Err(). The supplied context controls the
+// lifetime of the stream: cancelling it (or calling Close) tears the connection
+// down cleanly.
 //
 // Example:
 //

--- a/stream_test.go
+++ b/stream_test.go
@@ -310,8 +310,8 @@ func TestStreamSubscriptionRejected(t *testing.T) {
 	if _, ok := err.(*StreamRejectedError); !ok {
 		t.Fatalf("expected *StreamRejectedError, got %T: %v", err, err)
 	}
-	if !strings.Contains(err.Error(), "Professional+") {
-		t.Errorf("rejection error should mention Professional+, got %q", err.Error())
+	if !strings.Contains(err.Error(), "account entitlement") {
+		t.Errorf("rejection error should include recovery guidance, got %q", err.Error())
 	}
 }
 

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -162,9 +162,7 @@ func (c *Client) DeleteSubscription(ctx context.Context, id string) error {
 	return nil
 }
 
-// GetSubscriptionEvents polls the per-user event cursor (#3245 Phase 2). This
-// endpoint does NOT consume the monthly request quota, so agents may poll it
-// frequently.
+// GetSubscriptionEvents polls the per-user event cursor (#3245 Phase 2).
 //
 // Pass WithSince(cursor) to page forward from a previous response, WithEventLimit
 // to cap the page size, and WithEventWatchID to scope to a single subscription.

--- a/types.go
+++ b/types.go
@@ -1,7 +1,6 @@
 // Package oilpriceapi provides a Go client for the Oil Price API.
 //
-// The Oil Price API provides real-time and historical oil price data
-// for various commodities including Brent Crude, WTI, Natural Gas, and more.
+// OilPriceAPI provides source-timestamped energy data through a normalized API.
 //
 // Example usage:
 //
@@ -13,7 +12,11 @@
 //	fmt.Printf("Brent: $%.2f\n", prices.Data.Prices[0].Price)
 package oilpriceapi
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
 
 // DemoPrice represents a price in demo mode.
 type DemoPrice struct {
@@ -45,17 +48,54 @@ type DemoPricesResponse struct {
 
 // Price represents a single price entry.
 type Price struct {
-	Code      string  `json:"code"`
-	Name      string  `json:"name"`
-	Price     float64 `json:"price"`
-	Currency  string  `json:"currency"`
-	Unit      string  `json:"unit"`
-	UpdatedAt string  `json:"updated_at"`
+	Code        string  `json:"code"`
+	Name        string  `json:"name"`
+	Price       float64 `json:"price"`
+	Currency    string  `json:"currency"`
+	Unit        string  `json:"unit"`
+	Source      string  `json:"source,omitempty"`
+	CreatedAt   string  `json:"created_at,omitempty"`
+	UpdatedAt   string  `json:"updated_at"`
+	CollectedAt string  `json:"collected_at,omitempty"`
 }
 
 // PriceData contains the data from a prices response.
 type PriceData struct {
 	Prices []Price `json:"prices"`
+}
+
+// UnmarshalJSON accepts both the legacy {"prices":[...]} data envelope and
+// the singleton price object returned by the production latest-price endpoint.
+// A success response without either shape is rejected instead of appearing to
+// succeed with an empty result.
+func (d *PriceData) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	if rawPrices, ok := fields["prices"]; ok {
+		var prices []Price
+		if err := json.Unmarshal(rawPrices, &prices); err != nil {
+			return err
+		}
+		if len(prices) == 0 {
+			return errors.New("latest prices response contains an empty prices array")
+		}
+		d.Prices = prices
+		return nil
+	}
+
+	var price Price
+	if err := json.Unmarshal(data, &price); err != nil {
+		return err
+	}
+	if strings.TrimSpace(price.Code) == "" {
+		return errors.New("latest prices response contains neither a price object nor a prices array")
+	}
+
+	d.Prices = []Price{price}
+	return nil
 }
 
 // PricesResponse represents the response from /v1/prices/latest.
@@ -1036,7 +1076,7 @@ type RigCount struct {
 	UpdatedAt string  `json:"updated_at"`
 }
 
-// RigCountUpdate is a rig-count update broadcast (drilling / Professional+ accounts).
+// RigCountUpdate is a rig-count update broadcast.
 type RigCountUpdate struct {
 	Type      string   `json:"type"`
 	Timestamp string   `json:"timestamp"`
@@ -1164,9 +1204,9 @@ func WithNarrative(narrative bool) MarketBriefOption {
 // AGENT SUBSCRIPTIONS (#3245 Phase 2) — /v1/subscriptions
 // =============================================================================
 
-// Subscription is a persistent agent "watch" — a saved set of commodity codes
-// the platform re-evaluates on a fixed interval, emitting events when prices
-// move. It is returned by the subscription CRUD endpoints.
+// Subscription is a persistent agent "watch": a saved set of commodity codes
+// that emits events when configured conditions are met. It is returned by the
+// subscription CRUD endpoints.
 type Subscription struct {
 	ID              string   `json:"id"`
 	Name            string   `json:"name"`


### PR DESCRIPTION
Closes #18
Closes #23

## What changed

- decode the production singleton `/v1/prices/latest` payload into one `Data.Prices` entry while retaining the legacy array envelope
- reject malformed or empty 200 responses instead of silently returning zero prices
- publish the canonical `OILPRICEAPI_KEY` Brent first request with actionable missing-config, 401, 403, and 429 recovery
- replace unsupported mutable product claims with canonical product-facts, pricing, and data-rights links
- add public-surface drift checks, strict live production coverage, and a clean consumer-module release smoke
- align the SDK user agent and changelog on v1.4.0

## Verification

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `./scripts/clean-install-smoke.sh`
- strict production `TestLiveGetLatestPrice` with the rotated synthetic smoke identity
- `git diff --check`